### PR TITLE
Options type error (Issue #13)

### DIFF
--- a/src/main/scala/stdlib/Options.scala
+++ b/src/main/scala/stdlib/Options.scala
@@ -56,7 +56,7 @@ object Options extends FlatSpec with Matchers with exercise.Section {
 
   /** Option can also be used with pattern matching:
     */
-  def matchOptions(res0: Float, res1: Float) {
+  def matchOptions(res0: Double, res1: Double) {
     val someValue: Option[Double] = Some(20.0)
     val value = someValue match {
       case Some(v) ⇒ v

--- a/src/test/scala/exercises/stdlib/OptionsSpec.scala
+++ b/src/test/scala/exercises/stdlib/OptionsSpec.scala
@@ -42,7 +42,7 @@ class OptionsSpec extends Spec with Checkers {
     check(
       Test.testSuccess(
         Options.matchOptions _,
-        20F :: 0F :: HNil
+        20D :: 0D :: HNil
       )
     )
   }


### PR DESCRIPTION
Problem

Test in the options exercise throws an error because the test expects a Float instead of a Double from the user

Solution

Change type of argument to Doube