### PR TITLE
fix unused parameter

### DIFF
--- a/src/main/scala/stdlib/TypeSignatures.scala
+++ b/src/main/scala/stdlib/TypeSignatures.scala
@@ -50,7 +50,7 @@ object TypeSignatures extends FlatSpec with Matchers with exercise.Section {
     */
   def deriveMetaInformationTypeSignatures(res0: Boolean, res1: String, res2: String) {
     val zoom = "zoom"
-    zoom.getClass should be(classOf[String])
+    zoom.getClass.isInstanceOf[String] should be(res0)
     zoom.getClass.getCanonicalName should be(res1)
     zoom.getClass.getSimpleName should be(res2)
   }

--- a/src/main/scala/stdlib/TypeSignatures.scala
+++ b/src/main/scala/stdlib/TypeSignatures.scala
@@ -50,7 +50,7 @@ object TypeSignatures extends FlatSpec with Matchers with exercise.Section {
     */
   def deriveMetaInformationTypeSignatures(res0: Boolean, res1: String, res2: String) {
     val zoom = "zoom"
-    zoom.getClass.isInstanceOf[String] should be(res0)
+    zoom.isInstanceOf[String] should be(res0)
     zoom.getClass.getCanonicalName should be(res1)
     zoom.getClass.getSimpleName should be(res2)
   }


### PR DESCRIPTION
The website still needs to be fixed - there is a compilation error: deriveMetaInformationTypeSignatures cannot be completed due to "not enough arguments". (Exercise 30: Type Signatures, case 3)