### PR TITLE
Adding additional test case to Std Lib Maps

### DIFF
--- a/src/main/scala/stdlib/Maps.scala
+++ b/src/main/scala/stdlib/Maps.scala
@@ -78,6 +78,20 @@ object Maps extends FlatSpec with Matchers with exercise.Section {
     myMap("IA") should be(res1)
   }
 
+  /** If a map key is requested using myMap(missingKey) which does not exist a NoSuchElementException will be thrown.
+    * Default values may be provided using either getOrElse or withDefaultValue for the entire map
+    */
+  def defaultValuesMayBeProvidedMaps(res0: String, res1: String) {
+    val myMap = Map("MI" → "Michigan", "OH" → "Ohio", "WI" → "Wisconsin", "IA" → "Iowa")
+    intercept[NoSuchElementException] {
+      myMap("TX")
+    }
+    myMap.getOrElse("TX", "missing data") should be(res0)
+
+    val myMap2 = Map("MI" → "Michigan", "OH" → "Ohio", "WI" → "Wisconsin", "IA" → "Iowa") withDefaultValue "missing data"
+    myMap2("TX") should be(res1)
+  }
+
   /** Map elements can be removed easily:
     */
   def easilyRemovedMaps(res0: Boolean, res1: Boolean) {

--- a/src/test/scala/exercises/stdlib/MapSpec.scala
+++ b/src/test/scala/exercises/stdlib/MapSpec.scala
@@ -72,6 +72,15 @@ class MapsSpec extends Spec with Checkers {
     )
   }
 
+  def `map default value access` = {
+    check(
+      Test.testSuccess(
+        Maps.defaultValuesMayBeProvidedMaps _,
+        "missing data" :: "missing data" :: HNil
+      )
+    )
+  }
+
   def `map element removal` = {
     check(
       Test.testSuccess(


### PR DESCRIPTION
This case demonstrates the behavior of attempting to call myMap(missingKey) in that an exception is thrown. It also provides examples of how to handle this gracefully using default values via either getOrElse or for the entire map with withDefaultValue. Also included corresponding test case.