### PR TITLE
Implicits Chapter: Edits to docstrings, plus one code change

### DIFF
--- a/src/main/scala/stdlib/Implicits.scala
+++ b/src/main/scala/stdlib/Implicits.scala
@@ -8,9 +8,12 @@ import scala.language.implicitConversions
   */
 object Implicits extends FlatSpec with Matchers with org.scalaexercises.definitions.Section {
 
-  /** The actual arguments that are eligible to be passed to an implicit parameter fall into two categories: * First, eligible are all identifiers x that can be accessed at the point of the method call without a prefix and that denote an implicit definition or an implicit parameter. * Second, eligible are also all members of companion modules of the implicit parameter's type that are labeled implicit.
+  /** The actual arguments that are eligible to be passed to an implicit parameter fall into two categories: 
     *
-    * In the following example we define a method sum which computes the sum of a list of elements using the monoid's add and unit operations. Please note that implicit values can not be top-level, they have to be members of a template.
+    * - First, eligible are all identifiers x that can be accessed at the point of the method call without a prefix and that denote an implicit definition or an implicit parameter. 
+    * - Second, eligible are also all members of companion modules of the implicit parameter's type that are labeled implicit.
+    *
+    * In the following example we define a method `sum` which computes the sum of a list of elements using the monoid's `add` and `unit` operations. Please note that implicit values can not be top-level, they have to be members of a template.
     *
     * {{{
     * abstract class SemiGroup[A] {
@@ -45,7 +48,7 @@ object Implicits extends FlatSpec with Matchers with org.scalaexercises.definiti
     *
     * Implicits wrap around existing classes to provide extra functionality. This is similar to *monkey patching* in **Ruby**, and *Meta-Programming* in **Groovy**.
     *
-    * Creating a method isOdd for Int, which doesn't exist:
+    * Creating a method `isOdd` for `Int`, which doesn't exist:
     */
   def implicitsParametersImplicits(res0: Boolean, res1: Boolean) {
     class KoanIntWrapper(val original: Int) {
@@ -80,7 +83,7 @@ object Implicits extends FlatSpec with Matchers with org.scalaexercises.definiti
 
   /** convertTypeImplicits
     *
-    * Implicits can be used to automatically convert one type to another
+    * Implicits can be used to automatically convert a value's type to another:
     */
   def convertTypeImplicits(res0: Boolean, res1: Boolean, res2: Boolean, res3: Boolean, res4: Boolean) {
     import java.math.BigInteger
@@ -97,9 +100,9 @@ object Implicits extends FlatSpec with Matchers with org.scalaexercises.definiti
     add(3, 6).intValue == 9 should be(res4)
   }
 
-  /** Implicits can be used to declare a value to be provided as a default as long as an implicit value is set with in the scope.  These are called implicit function parameters:
+  /** Implicits can be used to declare a value to be provided as a default as long as an implicit value is set with in the scope.  These are called Implicit Function Parameters:
     */
-  def asDefaultImplicits(res0: Float) {
+  def asDefaultImplicits(res0: BigDecimal) {
     def howMuchCanIMake_?(hours: Int)(implicit dollarsPerHour: BigDecimal) = dollarsPerHour * hours
 
     implicit val hourlyRate = BigDecimal(34.00)
@@ -119,7 +122,7 @@ object Implicits extends FlatSpec with Matchers with org.scalaexercises.definiti
     howMuchCanIMake_?(30) should be(res0)
   }
 
-  /** Default arguments though are preferred to Implicit Function Parameters
+  /** Default arguments, though, are preferred to Implicit Function Parameters:
     */
   def defaultArgumentsImplicits(res0: String, res1: String) {
     def howMuchCanIMake_?(hours: Int, amount: BigDecimal = 34, currencyName: String = "Dollars") =

--- a/src/test/scala/stdlib/ImplicitsSpec.scala
+++ b/src/test/scala/stdlib/ImplicitsSpec.scala
@@ -35,8 +35,7 @@ class ImplicitsSpec extends Spec with Checkers {
   }
 
   def `implicits for default parameters` = {
-    val fstAnswer: Float = 1020.0f
-    val sndAnswer: Float = 9025.0f
+    val fstAnswer: BigDecimal = 1020.0f
 
     check(
       Test.testSuccess(


### PR DESCRIPTION
1. Fix markdown list at line 11
2. Add code backticks to some terms
3. Some edits (colons and capitalizing Implicit Function Parameters) for consistency w/ rest of doc
4. On line 105 
```diff
-def asDefaultImplicits(res0: Float) {
+def asDefaultImplicits(res0: BigDecimal) {
```
Since, I had to manually cast the answer on the koan to Float. IDK if this requires a change on somewhere else in the code, but can do it if you point me to the file.