### PR TITLE
Bumps to 0.2.4-SNAPSHOT version

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -5,7 +5,7 @@ lazy val stdlib = (project in file("."))
   organization := "org.scala-exercises",
   name         := "exercises-stdlib",
   scalaVersion := "2.11.7",
-  version := "0.2.3-SNAPSHOT",
+  version := "0.2.4-SNAPSHOT",
   resolvers ++= Seq(
     Resolver.sonatypeRepo("snapshots"),
     Resolver.sonatypeRepo("releases")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -2,5 +2,5 @@ resolvers ++= Seq(
   Resolver.sonatypeRepo("snapshots")
 )
 
-addSbtPlugin("org.scala-exercises" % "sbt-exercise" % "0.2.3-SNAPSHOT", "0.13", "2.10")
+addSbtPlugin("org.scala-exercises" % "sbt-exercise" % "0.2.4-SNAPSHOT", "0.13", "2.10")
 addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.0.0")


### PR DESCRIPTION
This new version makes that compiler does not provide the transitive dependencies.

Please, @raulraja could you take a look? Thanks.