### PR TITLE
Uses Integer values when creating BigDecimal values to avoid the decimal point when calling toString

### DIFF
--- a/src/main/scala/stdlib/Implicits.scala
+++ b/src/main/scala/stdlib/Implicits.scala
@@ -105,7 +105,7 @@ object Implicits extends FlatSpec with Matchers with org.scalaexercises.definiti
   def asDefaultImplicits(res0: BigDecimal) {
     def howMuchCanIMake_?(hours: Int)(implicit dollarsPerHour: BigDecimal) = dollarsPerHour * hours
 
-    implicit val hourlyRate = BigDecimal(34.00)
+    implicit val hourlyRate = BigDecimal(34)
 
     howMuchCanIMake_?(30) should be(res0)
   }
@@ -116,7 +116,7 @@ object Implicits extends FlatSpec with Matchers with org.scalaexercises.definiti
     def howMuchCanIMake_?(hours: Int)(implicit amount: BigDecimal, currencyName: String) =
       (amount * hours).toString() + " " + currencyName
 
-    implicit val hourlyRate = BigDecimal(34.00)
+    implicit val hourlyRate = BigDecimal(34)
     implicit val currencyName = "Dollars"
 
     howMuchCanIMake_?(30) should be(res0)

--- a/src/test/scala/stdlib/ImplicitsSpec.scala
+++ b/src/test/scala/stdlib/ImplicitsSpec.scala
@@ -35,7 +35,7 @@ class ImplicitsSpec extends Spec with Checkers {
   }
 
   def `implicits for default parameters` = {
-    val fstAnswer: BigDecimal = 1020.0f
+    val fstAnswer: BigDecimal = 1020
 
     check(
       Test.testSuccess(
@@ -49,7 +49,7 @@ class ImplicitsSpec extends Spec with Checkers {
     check(
       Test.testSuccess(
         Implicits.listOfImplicitsImplicits _,
-        "1020.0 Dollars" :: HNil
+        "1020 Dollars" :: HNil
       )
     )
   }


### PR DESCRIPTION
Seeing `BigDecimal(34.00).toString()` makes the programmer guess if the answer is `34`, `34.0` or `34.00`. Maybe it's simpler to have them all as `Integer` instead of `Double` and avoid the confusion.