### PR TITLE
Update Options.scala to improve clarity with option folding

### DIFF
--- a/src/main/scala/stdlib/Options.scala
+++ b/src/main/scala/stdlib/Options.scala
@@ -98,8 +98,8 @@ object Options extends FlatSpec with Matchers with org.scalaexercises.definition
   def foldOptions(res0: Int, res1: Int) {
     val number: Option[Int]   = Some(3)
     val noNumber: Option[Int] = None
-    val result1               = number.fold(0)(_ * 3)
-    val result2               = noNumber.fold(0)(_ * 3)
+    val result1               = number.fold(1)(_ * 3)
+    val result2               = noNumber.fold(1)(_ * 3)
 
     result1 should be(res0)
     result2 should be(res1)


### PR DESCRIPTION
Using `noNumber.fold(0)(_ * 3)` makes it unclear whether or not the default value goes through the same process. In other words, is the result 0 because that's the value we provide, or because `0 = 0 * 3`?

Using `val result2 = noNumber.fold(1)(_ * 3)` makes it clearer, as the result is 1 and not 3.