### PR TITLE
Expand the type signatures exercise with instanceof checks for a class and a trait

### DIFF
--- a/src/main/scala/stdlib/TypeSignatures.scala
+++ b/src/main/scala/stdlib/TypeSignatures.scala
@@ -62,7 +62,7 @@ object TypeSignatures extends FlatSpec with Matchers with org.scalaexercises.def
 
   /** `isInstanceOf[className]` is used to determine the if an object reference is an instance of given class:
    */
-  def isInstanceOfFunctionTypeSignatures(res0: Boolean) {
+  def isInstanceOfFunctionTypeSignatures(res0: Boolean, res1: Boolean, res2: Boolean) {
     trait Randomizer[A] {
       def draw(): A
     }
@@ -75,7 +75,9 @@ object TypeSignatures extends FlatSpec with Matchers with org.scalaexercises.def
     }
 
     val intRand = new IntRandomizer
-    intRand.draw.isInstanceOf[Int] should be(res0)
+    intRand.isInstanceOf[IntRandomizer] should be(res0)
+    intRand.isInstanceOf[Randomizer[Int]] should be(res1)
+    intRand.draw.isInstanceOf[Int] should be(res2)
   }
 
 }

--- a/src/test/scala/stdlib/TypeSignaturesSpec.scala
+++ b/src/test/scala/stdlib/TypeSignaturesSpec.scala
@@ -43,7 +43,7 @@ class TypeSignaturesSpec extends Spec with Checkers {
     check(
       Test.testSuccess(
         TypeSignatures.isInstanceOfFunctionTypeSignatures _,
-        true :: HNil
+        true :: true :: true :: HNil
       )
     )
   }


### PR DESCRIPTION
The exercise description says that `isInstanceOf[className]` is used to determine if an object reference is an instance of a given class, but it doesn't currently verify the most basic checks.