### PR TITLE
Sequences And Arrays: Change type of res0: from List to Seq

### DIFF
--- a/src/main/scala/stdlib/SequencesandArrays.scala
+++ b/src/main/scala/stdlib/SequencesandArrays.scala
@@ -69,7 +69,7 @@ object SequencesandArrays
 
   /** You can map values in a sequence through a function:
    */
-  def mapValuesSequencesandArrays(res0: List[String]) {
+  def mapValuesSequencesandArrays(res0: Seq[String]) {
     val s = Seq("hello", "world")
     val r = s map {
       _.reverse

--- a/src/test/scala/stdlib/SequencesAndArraysSpec.scala
+++ b/src/test/scala/stdlib/SequencesAndArraysSpec.scala
@@ -70,7 +70,7 @@ class SequencesAndArraysSpec extends Spec with Checkers {
     check(
       Test.testSuccess(
         SequencesandArrays.mapValuesSequencesandArrays _,
-        List("olleh", "dlrow") :: HNil
+        Seq("olleh", "dlrow") :: HNil
       )
     )
   }


### PR DESCRIPTION
If you try to compile with List[String] you receive type mismatch error:
"Error:() type mismatch;
 found   : Seq[String]
 required: List[String]
    val r: List[String] = s map {"