### PR TITLE
Update Traversables.scala

### DIFF
--- a/src/main/scala/stdlib/Traversables.scala
+++ b/src/main/scala/stdlib/Traversables.scala
@@ -149,7 +149,7 @@ object Traversables extends FlatSpec with Matchers with org.scalaexercises.defin
     result.isInstanceOf[IndexedSeq[_]] should be(res0)
   }
 
-  /** `toStream` will convert any `Traversable* to a `Stream` which is a lazy list where elements are evaluated as they are needed:
+  /** `toStream` will convert any `Traversable` to a `Stream` which is a lazy list where elements are evaluated as they are needed:
    */
   def toStreamFunctionTraversables(res0: Boolean, res1: Stream[Int]) {
     val list   = List(4, 6, 7, 8, 9, 13, 14)


### PR DESCRIPTION
Change asterisk to backquote to fix a problem with incorrect markdown formatting