### PR TITLE
Fix Sets "tuple" example because it's misleading

### DIFF
--- a/src/main/scala/stdlib/Sets.scala
+++ b/src/main/scala/stdlib/Sets.scala
@@ -82,15 +82,28 @@ object Sets extends FlatSpec with Matchers with org.scalaexercises.definitions.S
     aNewSet.size should be(res2)
   }
 
-  /** Set elements can be removed with a tuple:
+  /** Multiple elements can be removed from a Set using the overloaded - method:
    */
-  def tupleRemovingSets(res0: Boolean, res1: Boolean, res2: Int) {
+  def multiRemovingSets(
+      res0: Boolean,
+      res1: Boolean,
+      res2: Int,
+      res3: Boolean,
+      res4: Boolean,
+      res5: Boolean,
+      res6: Int) {
     val mySet   = Set("Michigan", "Ohio", "Wisconsin", "Iowa")
-    val aNewSet = mySet - ("Michigan", "Ohio") // Notice: single '-' operator for tuples
+    val aNewSet = mySet - ("Michigan", "Ohio") // Notice: single '-' operator can remove multiple elements
 
     aNewSet.contains("Michigan") should be(res0)
     aNewSet.contains("Wisconsin") should be(res1)
     aNewSet.size should be(res2)
+
+    val anotherNewSet = mySet - ("Michigan", "Ohio", "Iowa") // You can pass as 2 or more arguments, this method is varadiac!
+    anotherNewSet.contains("Michigan") should be(res3)
+    anotherNewSet.contains("Ohio") should be(res4)
+    anotherNewSet.contains("Iowa") should be(res5)
+    anotherNewSet.size should be(res6)
   }
 
   /** Attempted removal of nonexistent elements from a set is handled gracefully:

--- a/src/test/scala/stdlib/SetsSpec.scala
+++ b/src/test/scala/stdlib/SetsSpec.scala
@@ -75,11 +75,11 @@ class SetsSpec extends Spec with Checkers {
     )
   }
 
-  def `we can remove multiple members with tuples` = {
+  def `we can remove multiple members with the overloaded - method` = {
     check(
       Test.testSuccess(
-        Sets.tupleRemovingSets _,
-        false :: true :: 2 :: HNil
+        Sets.multiRemovingSets _,
+        false :: true :: 2 :: false :: false :: false :: 1 :: HNil
       )
     )
   }


### PR DESCRIPTION
This example is incorrect. The statement

```
Set(1,2,3) - (1,2)
```

for example does not use a tuple at all, it's the same thing as this:

```
Set(1,2,3).-(1,2)
```

Which is calling the overloaded version of the `-` method of `Set` which
accepts two initial arguments plus a varadiac list of however many
elements you want which allows you to do things like

```
Set(1,2,3,4) - (1,2,3,4,5) // etc
```

No where in this are tuples ever actually used. And to say so (as it
does currently) is misleading to programmers trying to use
scala-exercises as a way of learning the standard library. If you DID
try to use a tuple it would not work:

```
Set(1,2,3) - ((1,2)) //this will not compile
```