### PR TITLE
Update TypeSignatures.scala

### DIFF
--- a/src/main/scala/stdlib/TypeSignatures.scala
+++ b/src/main/scala/stdlib/TypeSignatures.scala
@@ -41,7 +41,7 @@ object TypeSignatures extends FlatSpec with Matchers with org.scalaexercises.def
     }
 
     val intRand = new IntRandomizer
-    (intRand.draw < Int.MaxValue) should be(res0)
+    (intRand.draw <= Int.MaxValue) should be(res0)
   }
 
   /** Class meta-information can be retrieved by class name by using `classOf[className]`:


### PR DESCRIPTION
I don't see any restrictions on Random.nextInt. Should assume you may get Int.MaxValue as next value.