### PR TITLE
Changing Traversables.scala slice description

### DIFF
--- a/src/main/scala/stdlib/Traversables.scala
+++ b/src/main/scala/stdlib/Traversables.scala
@@ -277,7 +277,7 @@ object Traversables extends FlatSpec with Matchers with org.scalaexercises.defin
     list.init should be(res0)
   }
 
-  /** Given a `from` index, and a `to` index, `slice` will return the part of the collection including `from`, and excluding `to`:
+  /** Given a `from` index, and a `until` index, `slice` will return the part of the collection including `from`, and excluding `until`:
    */
   def sliceFunctionTraversables(res0: List[Int]) {
     val list = List(10, 19, 45, 1, 22)


### PR DESCRIPTION
Changing ,,to" argument name to ,,until" as used in slice function source code. Second reson is that ,,to" and ,,until" have specific meaning in Scala, as represented in ranges where  ,,1 until 10" is equivalent to ,,1 to 9".