### PR TITLE
assert should be Nil instead of asserting true

### DIFF
--- a/src/main/scala/stdlib/PatternMatching.scala
+++ b/src/main/scala/stdlib/PatternMatching.scala
@@ -211,7 +211,7 @@ object PatternMatching extends FlatSpec with Matchers with org.scalaexercises.de
       case _                   ⇒ 0
     }
 
-    r == Nil should be(res0)
+    r should be(res0)
   }
 
 }


### PR DESCRIPTION
More readable to say `r should be Nil` than saying `r == Nil should be true`