### PR TITLE
Update Maps.scala - corrections to unary '-' using tuple which is deprecated in Scala 2.13.0

### DIFF
--- a/src/main/scala/stdlib/Maps.scala
+++ b/src/main/scala/stdlib/Maps.scala
@@ -127,11 +127,12 @@ object Maps extends FlatSpec with Matchers with org.scalaexercises.definitions.S
   }
 
   /** Map elements can be removed with a tuple:
+   *  '-' Operator is deprecated on MapOps from scala 2.13.0
    */
   def removedWithTupleMaps(res0: Boolean, res1: Boolean, res2: Boolean, res3: Int, res4: Int) {
     val myMap =
       Map("MI" → "Michigan", "OH" → "Ohio", "WI" → "Wisconsin", "IA" → "Iowa")
-    val aNewMap = myMap - ("MI", "WI") // Notice: single '-' operator for tuples
+    val aNewMap = myMap - ("MI", "WI") // Notice: single '-' operator for tuples; works, but deprecated starting scala 2.13.0
 
     aNewMap.contains("MI") should be(res0)
     myMap.contains("MI") should be(res1)


### PR DESCRIPTION
scala> myMap - ("MI", "IA")
             ^
       warning: method - in trait MapOps is deprecated (since 2.13.0): Use -- with an explicit collection
res1: scala.collection.immutable.Map[String,String] = Map(OH -> Ohio, WI -> Wisconsin)