### PR TITLE
Exercises Update and Removed Deprecation Warnings

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -10,9 +10,9 @@ lazy val stdlib = (project in file("."))
     libraryDependencies ++= Seq(
       dep("exercise-compiler"),
       dep("definitions"),
-      %%("shapeless, V.shapeless),
-      "org.scalatest"              %% "scalatest"                 % V.scalatest,
-      "org.scalacheck"             %% "scalacheck"                % V.scalacheck,
+      %%("shapeless", V.shapeless),
+      %%("scalatest", V.scalatest),
+      %%("scalacheck", V.scalacheck),
       "com.github.alexarchambault" %% "scalacheck-shapeless_1.14" % V.scalacheckShapeless
     )
   )

--- a/build.sbt
+++ b/build.sbt
@@ -10,7 +10,7 @@ lazy val stdlib = (project in file("."))
     libraryDependencies ++= Seq(
       dep("exercise-compiler"),
       dep("definitions"),
-      "com.chuusai"                %% "shapeless"                 % "2.3.3",
+      %%("shapeless, V.shapeless),
       "org.scalatest"              %% "scalatest"                 % V.scalatest,
       "org.scalacheck"             %% "scalacheck"                % V.scalacheck,
       "com.github.alexarchambault" %% "scalacheck-shapeless_1.14" % V.scalacheckShapeless

--- a/build.sbt
+++ b/build.sbt
@@ -10,10 +10,10 @@ lazy val stdlib = (project in file("."))
     libraryDependencies ++= Seq(
       dep("exercise-compiler"),
       dep("definitions"),
-      %%("shapeless"),
-      %%("scalatest"),
-      %%("scalacheck"),
-      %%("scheckShapeless")
+      "com.chuusai"                %% "shapeless"                 % "2.3.3",
+      "org.scalatest"              %% "scalatest"                 % V.scalatest,
+      "org.scalacheck"             %% "scalacheck"                % V.scalacheck,
+      "com.github.alexarchambault" %% "scalacheck-shapeless_1.14" % V.scalacheckShapeless
     )
   )
 

--- a/project/ProjectPlugin.scala
+++ b/project/ProjectPlugin.scala
@@ -16,7 +16,11 @@ object ProjectPlugin extends AutoPlugin {
   object autoImport {
 
     lazy val V = new {
-      val scala212: String = "2.12.10"
+      val scala212: String            = "2.12.10"
+      val shapeless: String           = "2.3.3"
+      val scalatest: String           = "3.0.8"
+      val scalacheck: String          = "1.14.2"
+      val scalacheckShapeless: String = "1.2.3"
     }
   }
 

--- a/project/ProjectPlugin.scala
+++ b/project/ProjectPlugin.scala
@@ -48,7 +48,7 @@ object ProjectPlugin extends AutoPlugin {
       ),
       scalacOptions := sbtorgpolicies.model.scalacCommonOptions,
       headerLicense := Some(Custom(s"""| scala-exercises - ${name.value}
-                                       | Copyright (C) 2015-2016 47 Degrees, LLC. <http://www.47deg.com>
+                                       | Copyright (C) 2015-2019 47 Degrees, LLC. <http://www.47deg.com>
                                        |
                                        |""".stripMargin))
     )

--- a/src/main/scala/stdlib/Asserts.scala
+++ b/src/main/scala/stdlib/Asserts.scala
@@ -1,6 +1,6 @@
 /*
  *  scala-exercises - exercises-stdlib
- *  Copyright (C) 2015-2016 47 Degrees, LLC. <http://www.47deg.com>
+ *  Copyright (C) 2015-2019 47 Degrees, LLC. <http://www.47deg.com>
  *
  */
 

--- a/src/main/scala/stdlib/ByNameParameter.scala
+++ b/src/main/scala/stdlib/ByNameParameter.scala
@@ -1,6 +1,6 @@
 /*
  *  scala-exercises - exercises-stdlib
- *  Copyright (C) 2015-2016 47 Degrees, LLC. <http://www.47deg.com>
+ *  Copyright (C) 2015-2019 47 Degrees, LLC. <http://www.47deg.com>
  *
  */
 

--- a/src/main/scala/stdlib/CaseClasses.scala
+++ b/src/main/scala/stdlib/CaseClasses.scala
@@ -1,6 +1,6 @@
 /*
  *  scala-exercises - exercises-stdlib
- *  Copyright (C) 2015-2016 47 Degrees, LLC. <http://www.47deg.com>
+ *  Copyright (C) 2015-2019 47 Degrees, LLC. <http://www.47deg.com>
  *
  */
 

--- a/src/main/scala/stdlib/Classes.scala
+++ b/src/main/scala/stdlib/Classes.scala
@@ -1,6 +1,6 @@
 /*
  *  scala-exercises - exercises-stdlib
- *  Copyright (C) 2015-2016 47 Degrees, LLC. <http://www.47deg.com>
+ *  Copyright (C) 2015-2019 47 Degrees, LLC. <http://www.47deg.com>
  *
  */
 

--- a/src/main/scala/stdlib/EmptyValues.scala
+++ b/src/main/scala/stdlib/EmptyValues.scala
@@ -1,6 +1,6 @@
 /*
  *  scala-exercises - exercises-stdlib
- *  Copyright (C) 2015-2016 47 Degrees, LLC. <http://www.47deg.com>
+ *  Copyright (C) 2015-2019 47 Degrees, LLC. <http://www.47deg.com>
  *
  */
 

--- a/src/main/scala/stdlib/Enumerations.scala
+++ b/src/main/scala/stdlib/Enumerations.scala
@@ -1,6 +1,6 @@
 /*
  *  scala-exercises - exercises-stdlib
- *  Copyright (C) 2015-2016 47 Degrees, LLC. <http://www.47deg.com>
+ *  Copyright (C) 2015-2019 47 Degrees, LLC. <http://www.47deg.com>
  *
  */
 

--- a/src/main/scala/stdlib/Extractors.scala
+++ b/src/main/scala/stdlib/Extractors.scala
@@ -71,7 +71,7 @@ object Extractors extends FlatSpec with Matchers with org.scalaexercises.definit
     class Car(val make: String, val model: String, val year: Short, val topSpeed: Short)
 
     object ChopShop {
-      def unapply(x: Car) = Some(x.make, x.model, x.year, x.topSpeed)
+      def unapply(x: Car) = Some((x.make, x.model, x.year, x.topSpeed))
     }
 
     val ChopShop(a, b, c, d) = new Car("Chevy", "Camaro", 1978, 120)
@@ -88,7 +88,7 @@ object Extractors extends FlatSpec with Matchers with org.scalaexercises.definit
     class Car(val make: String, val model: String, val year: Short, val topSpeed: Short)
 
     object ChopShop {
-      def unapply(x: Car) = Some(x.make, x.model, x.year, x.topSpeed)
+      def unapply(x: Car) = Some((x.make, x.model, x.year, x.topSpeed))
     }
 
     val x = new Car("Chevy", "Camaro", 1978, 120) match {
@@ -106,7 +106,7 @@ object Extractors extends FlatSpec with Matchers with org.scalaexercises.definit
     class Car(val make: String, val model: String, val year: Short, val topSpeed: Short)
 
     object ChopShop {
-      def unapply(x: Car) = Some(x.make, x.model, x.year, x.topSpeed)
+      def unapply(x: Car) = Some((x.make, x.model, x.year, x.topSpeed))
     }
 
     val x = new Car("Chevy", "Camaro", 1978, 120) match {
@@ -125,9 +125,9 @@ object Extractors extends FlatSpec with Matchers with org.scalaexercises.definit
     class Employee(val firstName: String, val middleName: Option[String], val lastName: String)
 
     object Tokenizer {
-      def unapply(x: Car) = Some(x.make, x.model, x.year, x.topSpeed)
+      def unapply(x: Car) = Some((x.make, x.model, x.year, x.topSpeed))
 
-      def unapply(x: Employee) = Some(x.firstName, x.lastName)
+      def unapply(x: Employee) = Some((x.firstName, x.lastName))
     }
 
     val result = new Employee("Kurt", None, "Vonnegut") match {
@@ -142,7 +142,7 @@ object Extractors extends FlatSpec with Matchers with org.scalaexercises.definit
    */
   def anyObjectExtractors(res0: String) {
     class Car(val make: String, val model: String, val year: Short, val topSpeed: Short) {
-      def unapply(x: Car) = Some(x.make, x.model)
+      def unapply(x: Car) = Some((x.make, x.model))
     }
 
     val camaro = new Car("Chevy", "Camaro", 1978, 122)
@@ -168,7 +168,7 @@ object Extractors extends FlatSpec with Matchers with org.scalaexercises.definit
       //factory methods, extractors, apply
       //Extractor: Create tokens that represent your object
       def unapply(x: Employee) =
-        Some(x.lastName, x.middleName, x.firstName)
+        Some((x.lastName, x.middleName, x.firstName))
     }
 
     val singri = new Employee("Singri", None, "Keerthi")
@@ -193,7 +193,7 @@ object Extractors extends FlatSpec with Matchers with org.scalaexercises.definit
       //factory methods, extractors, apply
       //Extractor: Create tokens that represent your object
       def unapply(x: Employee) =
-        Some(x.lastName, x.middleName, x.firstName)
+        Some((x.lastName, x.middleName, x.firstName))
     }
 
     val singri = new Employee("Singri", None, "Keerthi")

--- a/src/main/scala/stdlib/Extractors.scala
+++ b/src/main/scala/stdlib/Extractors.scala
@@ -1,6 +1,6 @@
 /*
  *  scala-exercises - exercises-stdlib
- *  Copyright (C) 2015-2016 47 Degrees, LLC. <http://www.47deg.com>
+ *  Copyright (C) 2015-2019 47 Degrees, LLC. <http://www.47deg.com>
  *
  */
 

--- a/src/main/scala/stdlib/ForExpressions.scala
+++ b/src/main/scala/stdlib/ForExpressions.scala
@@ -1,6 +1,6 @@
 /*
  *  scala-exercises - exercises-stdlib
- *  Copyright (C) 2015-2016 47 Degrees, LLC. <http://www.47deg.com>
+ *  Copyright (C) 2015-2019 47 Degrees, LLC. <http://www.47deg.com>
  *
  */
 

--- a/src/main/scala/stdlib/Formatting.scala
+++ b/src/main/scala/stdlib/Formatting.scala
@@ -1,6 +1,6 @@
 /*
  *  scala-exercises - exercises-stdlib
- *  Copyright (C) 2015-2016 47 Degrees, LLC. <http://www.47deg.com>
+ *  Copyright (C) 2015-2019 47 Degrees, LLC. <http://www.47deg.com>
  *
  */
 

--- a/src/main/scala/stdlib/Formatting.scala
+++ b/src/main/scala/stdlib/Formatting.scala
@@ -33,18 +33,16 @@ object Formatting extends FlatSpec with Matchers with org.scalaexercises.definit
     "%c".format(b) should be(res1)
   }
 
-  /** Character Literals can be an escape sequence, including octal or hexidecimal:
+  /** Character Literals can be an escape sequence, including hexidecimal:
    */
-  def escapeSequenceFormatting(res0: String, res1: String, res2: String, res3: String) {
+  def escapeSequenceFormatting(res0: String, res1: String, res2: String) {
     val c = '\u0061' //unicode for a
-    val d = '\141' //octal for a
     val e = '\"'
     val f = '\\'
 
     "%c".format(c) should be(res0)
-    "%c".format(d) should be(res1)
-    "%c".format(e) should be(res2)
-    "%c".format(f) should be(res3)
+    "%c".format(e) should be(res1)
+    "%c".format(f) should be(res2)
   }
 
   /** Formatting can also include numbers:

--- a/src/main/scala/stdlib/HigherOrderFunctions.scala
+++ b/src/main/scala/stdlib/HigherOrderFunctions.scala
@@ -1,6 +1,6 @@
 /*
  *  scala-exercises - exercises-stdlib
- *  Copyright (C) 2015-2016 47 Degrees, LLC. <http://www.47deg.com>
+ *  Copyright (C) 2015-2019 47 Degrees, LLC. <http://www.47deg.com>
  *
  */
 

--- a/src/main/scala/stdlib/Implicits.scala
+++ b/src/main/scala/stdlib/Implicits.scala
@@ -1,6 +1,6 @@
 /*
  *  scala-exercises - exercises-stdlib
- *  Copyright (C) 2015-2016 47 Degrees, LLC. <http://www.47deg.com>
+ *  Copyright (C) 2015-2019 47 Degrees, LLC. <http://www.47deg.com>
  *
  */
 

--- a/src/main/scala/stdlib/InfixPrefixandPostfixOperators.scala
+++ b/src/main/scala/stdlib/InfixPrefixandPostfixOperators.scala
@@ -1,6 +1,6 @@
 /*
  *  scala-exercises - exercises-stdlib
- *  Copyright (C) 2015-2016 47 Degrees, LLC. <http://www.47deg.com>
+ *  Copyright (C) 2015-2019 47 Degrees, LLC. <http://www.47deg.com>
  *
  */
 

--- a/src/main/scala/stdlib/InfixTypes.scala
+++ b/src/main/scala/stdlib/InfixTypes.scala
@@ -1,6 +1,6 @@
 /*
  *  scala-exercises - exercises-stdlib
- *  Copyright (C) 2015-2016 47 Degrees, LLC. <http://www.47deg.com>
+ *  Copyright (C) 2015-2019 47 Degrees, LLC. <http://www.47deg.com>
  *
  */
 

--- a/src/main/scala/stdlib/Iterables.scala
+++ b/src/main/scala/stdlib/Iterables.scala
@@ -1,6 +1,6 @@
 /*
  *  scala-exercises - exercises-stdlib
- *  Copyright (C) 2015-2016 47 Degrees, LLC. <http://www.47deg.com>
+ *  Copyright (C) 2015-2019 47 Degrees, LLC. <http://www.47deg.com>
  *
  */
 

--- a/src/main/scala/stdlib/Lists.scala
+++ b/src/main/scala/stdlib/Lists.scala
@@ -1,6 +1,6 @@
 /*
  *  scala-exercises - exercises-stdlib
- *  Copyright (C) 2015-2016 47 Degrees, LLC. <http://www.47deg.com>
+ *  Copyright (C) 2015-2019 47 Degrees, LLC. <http://www.47deg.com>
  *
  */
 

--- a/src/main/scala/stdlib/LiteralBooleans.scala
+++ b/src/main/scala/stdlib/LiteralBooleans.scala
@@ -1,6 +1,6 @@
 /*
  *  scala-exercises - exercises-stdlib
- *  Copyright (C) 2015-2016 47 Degrees, LLC. <http://www.47deg.com>
+ *  Copyright (C) 2015-2019 47 Degrees, LLC. <http://www.47deg.com>
  *
  */
 

--- a/src/main/scala/stdlib/LiteralNumbers.scala
+++ b/src/main/scala/stdlib/LiteralNumbers.scala
@@ -1,6 +1,6 @@
 /*
  *  scala-exercises - exercises-stdlib
- *  Copyright (C) 2015-2016 47 Degrees, LLC. <http://www.47deg.com>
+ *  Copyright (C) 2015-2019 47 Degrees, LLC. <http://www.47deg.com>
  *
  */
 

--- a/src/main/scala/stdlib/LiteralStrings.scala
+++ b/src/main/scala/stdlib/LiteralStrings.scala
@@ -1,6 +1,6 @@
 /*
  *  scala-exercises - exercises-stdlib
- *  Copyright (C) 2015-2016 47 Degrees, LLC. <http://www.47deg.com>
+ *  Copyright (C) 2015-2019 47 Degrees, LLC. <http://www.47deg.com>
  *
  */
 

--- a/src/main/scala/stdlib/LiteralStrings.scala
+++ b/src/main/scala/stdlib/LiteralStrings.scala
@@ -31,13 +31,6 @@ object LiteralStrings extends FlatSpec with Matchers with org.scalaexercises.def
     c.toString should be(res0)
   }
 
-  /** Character literals can use octal as well:
-   */
-  def characterLiteralsOctalLiteralStrings(res0: String) {
-    val d = '\141' //octal for a
-    d.toString should be(res0)
-  }
-
   /** Character literals can use escape sequences:
    */
   def escapeSequenceLiteralStrings(res0: String, res1: String) {

--- a/src/main/scala/stdlib/Maps.scala
+++ b/src/main/scala/stdlib/Maps.scala
@@ -1,6 +1,6 @@
 /*
  *  scala-exercises - exercises-stdlib
- *  Copyright (C) 2015-2016 47 Degrees, LLC. <http://www.47deg.com>
+ *  Copyright (C) 2015-2019 47 Degrees, LLC. <http://www.47deg.com>
  *
  */
 

--- a/src/main/scala/stdlib/NamedandDefaultArguments.scala
+++ b/src/main/scala/stdlib/NamedandDefaultArguments.scala
@@ -1,6 +1,6 @@
 /*
  *  scala-exercises - exercises-stdlib
- *  Copyright (C) 2015-2016 47 Degrees, LLC. <http://www.47deg.com>
+ *  Copyright (C) 2015-2019 47 Degrees, LLC. <http://www.47deg.com>
  *
  */
 

--- a/src/main/scala/stdlib/NamedandDefaultArgumentsHelper.scala
+++ b/src/main/scala/stdlib/NamedandDefaultArgumentsHelper.scala
@@ -1,6 +1,6 @@
 /*
  *  scala-exercises - exercises-stdlib
- *  Copyright (C) 2015-2016 47 Degrees, LLC. <http://www.47deg.com>
+ *  Copyright (C) 2015-2019 47 Degrees, LLC. <http://www.47deg.com>
  *
  */
 

--- a/src/main/scala/stdlib/Objects.scala
+++ b/src/main/scala/stdlib/Objects.scala
@@ -1,6 +1,6 @@
 /*
  *  scala-exercises - exercises-stdlib
- *  Copyright (C) 2015-2016 47 Degrees, LLC. <http://www.47deg.com>
+ *  Copyright (C) 2015-2019 47 Degrees, LLC. <http://www.47deg.com>
  *
  */
 

--- a/src/main/scala/stdlib/Options.scala
+++ b/src/main/scala/stdlib/Options.scala
@@ -1,6 +1,6 @@
 /*
  *  scala-exercises - exercises-stdlib
- *  Copyright (C) 2015-2016 47 Degrees, LLC. <http://www.47deg.com>
+ *  Copyright (C) 2015-2019 47 Degrees, LLC. <http://www.47deg.com>
  *
  */
 

--- a/src/main/scala/stdlib/OptionsHelper.scala
+++ b/src/main/scala/stdlib/OptionsHelper.scala
@@ -1,6 +1,6 @@
 /*
  *  scala-exercises - exercises-stdlib
- *  Copyright (C) 2015-2016 47 Degrees, LLC. <http://www.47deg.com>
+ *  Copyright (C) 2015-2019 47 Degrees, LLC. <http://www.47deg.com>
  *
  */
 

--- a/src/main/scala/stdlib/ParentClasses.scala
+++ b/src/main/scala/stdlib/ParentClasses.scala
@@ -1,6 +1,6 @@
 /*
  *  scala-exercises - exercises-stdlib
- *  Copyright (C) 2015-2016 47 Degrees, LLC. <http://www.47deg.com>
+ *  Copyright (C) 2015-2019 47 Degrees, LLC. <http://www.47deg.com>
  *
  */
 

--- a/src/main/scala/stdlib/PartialFunctions.scala
+++ b/src/main/scala/stdlib/PartialFunctions.scala
@@ -1,6 +1,6 @@
 /*
  *  scala-exercises - exercises-stdlib
- *  Copyright (C) 2015-2016 47 Degrees, LLC. <http://www.47deg.com>
+ *  Copyright (C) 2015-2019 47 Degrees, LLC. <http://www.47deg.com>
  *
  */
 

--- a/src/main/scala/stdlib/PartiallyAppliedFunctions.scala
+++ b/src/main/scala/stdlib/PartiallyAppliedFunctions.scala
@@ -1,6 +1,6 @@
 /*
  *  scala-exercises - exercises-stdlib
- *  Copyright (C) 2015-2016 47 Degrees, LLC. <http://www.47deg.com>
+ *  Copyright (C) 2015-2019 47 Degrees, LLC. <http://www.47deg.com>
  *
  */
 

--- a/src/main/scala/stdlib/PatternMatching.scala
+++ b/src/main/scala/stdlib/PatternMatching.scala
@@ -1,6 +1,6 @@
 /*
  *  scala-exercises - exercises-stdlib
- *  Copyright (C) 2015-2016 47 Degrees, LLC. <http://www.47deg.com>
+ *  Copyright (C) 2015-2019 47 Degrees, LLC. <http://www.47deg.com>
  *
  */
 

--- a/src/main/scala/stdlib/Ranges.scala
+++ b/src/main/scala/stdlib/Ranges.scala
@@ -1,6 +1,6 @@
 /*
  *  scala-exercises - exercises-stdlib
- *  Copyright (C) 2015-2016 47 Degrees, LLC. <http://www.47deg.com>
+ *  Copyright (C) 2015-2019 47 Degrees, LLC. <http://www.47deg.com>
  *
  */
 

--- a/src/main/scala/stdlib/RepeatedParameters.scala
+++ b/src/main/scala/stdlib/RepeatedParameters.scala
@@ -1,6 +1,6 @@
 /*
  *  scala-exercises - exercises-stdlib
- *  Copyright (C) 2015-2016 47 Degrees, LLC. <http://www.47deg.com>
+ *  Copyright (C) 2015-2019 47 Degrees, LLC. <http://www.47deg.com>
  *
  */
 

--- a/src/main/scala/stdlib/RepeatedParametersHelper.scala
+++ b/src/main/scala/stdlib/RepeatedParametersHelper.scala
@@ -1,6 +1,6 @@
 /*
  *  scala-exercises - exercises-stdlib
- *  Copyright (C) 2015-2016 47 Degrees, LLC. <http://www.47deg.com>
+ *  Copyright (C) 2015-2019 47 Degrees, LLC. <http://www.47deg.com>
  *
  */
 

--- a/src/main/scala/stdlib/SequencesandArrays.scala
+++ b/src/main/scala/stdlib/SequencesandArrays.scala
@@ -1,6 +1,6 @@
 /*
  *  scala-exercises - exercises-stdlib
- *  Copyright (C) 2015-2016 47 Degrees, LLC. <http://www.47deg.com>
+ *  Copyright (C) 2015-2019 47 Degrees, LLC. <http://www.47deg.com>
  *
  */
 

--- a/src/main/scala/stdlib/Sets.scala
+++ b/src/main/scala/stdlib/Sets.scala
@@ -1,6 +1,6 @@
 /*
  *  scala-exercises - exercises-stdlib
- *  Copyright (C) 2015-2016 47 Degrees, LLC. <http://www.47deg.com>
+ *  Copyright (C) 2015-2019 47 Degrees, LLC. <http://www.47deg.com>
  *
  */
 

--- a/src/main/scala/stdlib/StdLib.scala
+++ b/src/main/scala/stdlib/StdLib.scala
@@ -1,6 +1,6 @@
 /*
  *  scala-exercises - exercises-stdlib
- *  Copyright (C) 2015-2016 47 Degrees, LLC. <http://www.47deg.com>
+ *  Copyright (C) 2015-2019 47 Degrees, LLC. <http://www.47deg.com>
  *
  */
 

--- a/src/main/scala/stdlib/Traits.scala
+++ b/src/main/scala/stdlib/Traits.scala
@@ -1,6 +1,6 @@
 /*
  *  scala-exercises - exercises-stdlib
- *  Copyright (C) 2015-2016 47 Degrees, LLC. <http://www.47deg.com>
+ *  Copyright (C) 2015-2019 47 Degrees, LLC. <http://www.47deg.com>
  *
  */
 

--- a/src/main/scala/stdlib/Traversables.scala
+++ b/src/main/scala/stdlib/Traversables.scala
@@ -1,6 +1,6 @@
 /*
  *  scala-exercises - exercises-stdlib
- *  Copyright (C) 2015-2016 47 Degrees, LLC. <http://www.47deg.com>
+ *  Copyright (C) 2015-2019 47 Degrees, LLC. <http://www.47deg.com>
  *
  */
 

--- a/src/main/scala/stdlib/Traversables.scala
+++ b/src/main/scala/stdlib/Traversables.scala
@@ -424,54 +424,38 @@ object Traversables extends FlatSpec with Matchers with org.scalaexercises.defin
     result should be(res0)
   }
 
-  /** `/:` or `foldLeft` will combine an operation starting with a seed and combining from the left.  `foldLeft` is defined as (seed /: list), where seed is the initial value.  Once the fold is established, you provide a function that takes two arguments.  The first argument is the running total of the operation, and the second element is the next element of the list.
+  /** `foldLeft` will combine an operation starting with a seed and combining from the left.  `foldLeft` takes as a first parameter the initial value of the fold.  Once the fold is established, you provide a function that takes two arguments.  The first argument is the running total of the operation, and the second element is the next element of the list.
    *
    * Given a `Traversable (x1, x2, x3, x4)`, an initial value of `init`, an operation `op`, `foldLeft` is defined as: `(((init op x1) op x2) op x3) op x4)`
    */
-  def foldLeftFunctionTraversables(res0: Int, res1: Int, res2: Int, res3: Int, res4: Int) {
+  def foldLeftFunctionTraversables(res0: Int, res1: Int, res2: Int) {
     val list = List(5, 4, 3, 2, 1)
-    val result = (0 /: list) { (`running total`, `next element`) ⇒
+    val result = list.foldLeft(0) { (`running total`, `next element`) ⇒
       `running total` - `next element`
     }
     result should be(res0)
 
-    val result2 = list.foldLeft(0) { (`running total`, `next element`) ⇒
-      `running total` - `next element`
-    }
+    val result2 = list.foldLeft(0)(_ - _) //Short hand
     result2 should be(res1)
 
-    val result3 = (0 /: list)(_ - _) //Short hand
-    result3 should be(res2)
-
-    val result4 = list.foldLeft(0)(_ - _)
-    result4 should be(res3)
-
-    (((((0 - 5) - 4) - 3) - 2) - 1) should be(res4)
+    (((((0 - 5) - 4) - 3) - 2) - 1) should be(res2)
   }
 
-  /** `:\` or `foldRight` will combine an operation starting with a seed and combining from the right.  Fold right is defined as (list :\ seed), where seed is the initial value.  Once the fold is established, you  provide a function that takes two elements.  The first is the next element of the list, and the second element is the running total of the operation.
+  /** `foldRight` will combine an operation starting with a seed and combining from the right.  `foldRight` takes as a first parameter the initial value of the fold.  Once the fold is established, you  provide a function that takes two elements.  The first is the next element of the list, and the second element is the running total of the operation.
    *
    * Given a `Traversable (x1, x2, x3, x4)`, an initial value of `init`, an operation `op`, `foldRight` is defined as: `x1 op (x2 op (x3 op (x4 op init)))`
    */
-  def foldRightFunctionTraversables(res0: Int, res1: Int, res2: Int, res3: Int, res4: Int) {
+  def foldRightFunctionTraversables(res0: Int, res1: Int, res2: Int) {
     val list = List(5, 4, 3, 2, 1)
-    val result = (list :\ 0) { (`next element`, `running total`) ⇒
+    val result = list.foldRight(0) { (`next element`, `running total`) ⇒
       `next element` - `running total`
     }
     result should be(res0)
 
-    val result2 = list.foldRight(0) { (`next element`, `running total`) ⇒
-      `next element` - `running total`
-    }
+    val result2 = list.foldRight(0)(_ - _) //Short hand
     result2 should be(res1)
 
-    val result3 = (list :\ 0)(_ - _) //Short hand
-    result3 should be(res2)
-
-    val result4 = list.foldRight(0)(_ - _)
-    result4 should be(res3)
-
-    (5 - (4 - (3 - (2 - (1 - 0))))) should be(res4)
+    (5 - (4 - (3 - (2 - (1 - 0))))) should be(res2)
   }
 
   /** `reduceLeft` is similar to `foldLeft`, except that the seed is the head value:

--- a/src/main/scala/stdlib/Tuples.scala
+++ b/src/main/scala/stdlib/Tuples.scala
@@ -1,6 +1,6 @@
 /*
  *  scala-exercises - exercises-stdlib
- *  Copyright (C) 2015-2016 47 Degrees, LLC. <http://www.47deg.com>
+ *  Copyright (C) 2015-2019 47 Degrees, LLC. <http://www.47deg.com>
  *
  */
 

--- a/src/main/scala/stdlib/TypeSignatures.scala
+++ b/src/main/scala/stdlib/TypeSignatures.scala
@@ -1,6 +1,6 @@
 /*
  *  scala-exercises - exercises-stdlib
- *  Copyright (C) 2015-2016 47 Degrees, LLC. <http://www.47deg.com>
+ *  Copyright (C) 2015-2019 47 Degrees, LLC. <http://www.47deg.com>
  *
  */
 

--- a/src/main/scala/stdlib/TypeVariance.scala
+++ b/src/main/scala/stdlib/TypeVariance.scala
@@ -1,6 +1,6 @@
 /*
  *  scala-exercises - exercises-stdlib
- *  Copyright (C) 2015-2016 47 Degrees, LLC. <http://www.47deg.com>
+ *  Copyright (C) 2015-2019 47 Degrees, LLC. <http://www.47deg.com>
  *
  */
 

--- a/src/main/scala/stdlib/TypeVarianceHelper.scala
+++ b/src/main/scala/stdlib/TypeVarianceHelper.scala
@@ -1,6 +1,6 @@
 /*
  *  scala-exercises - exercises-stdlib
- *  Copyright (C) 2015-2016 47 Degrees, LLC. <http://www.47deg.com>
+ *  Copyright (C) 2015-2019 47 Degrees, LLC. <http://www.47deg.com>
  *
  */
 

--- a/src/main/scala/stdlib/UniformAccessPrinciple.scala
+++ b/src/main/scala/stdlib/UniformAccessPrinciple.scala
@@ -1,6 +1,6 @@
 /*
  *  scala-exercises - exercises-stdlib
- *  Copyright (C) 2015-2016 47 Degrees, LLC. <http://www.47deg.com>
+ *  Copyright (C) 2015-2019 47 Degrees, LLC. <http://www.47deg.com>
  *
  */
 

--- a/src/test/scala/stdlib/AssertsSpec.scala
+++ b/src/test/scala/stdlib/AssertsSpec.scala
@@ -1,6 +1,6 @@
 /*
  *  scala-exercises - exercises-stdlib
- *  Copyright (C) 2015-2016 47 Degrees, LLC. <http://www.47deg.com>
+ *  Copyright (C) 2015-2019 47 Degrees, LLC. <http://www.47deg.com>
  *
  */
 
@@ -9,7 +9,7 @@ package stdlib
 import org.scalacheck.ScalacheckShapeless._
 import org.scalaexercises.Test
 import org.scalatest.refspec.RefSpec
-import org.scalatest.prop.Checkers
+import org.scalatestplus.scalacheck.Checkers
 import shapeless.HNil
 
 class AssertsSpec extends RefSpec with Checkers {

--- a/src/test/scala/stdlib/AssertsSpec.scala
+++ b/src/test/scala/stdlib/AssertsSpec.scala
@@ -6,13 +6,13 @@
 
 package stdlib
 
-import org.scalacheck.Shapeless._
+import org.scalacheck.ScalacheckShapeless._
 import org.scalaexercises.Test
-import org.scalatest.Spec
+import org.scalatest.refspec.RefSpec
 import org.scalatest.prop.Checkers
 import shapeless.HNil
 
-class AssertsSpec extends Spec with Checkers {
+class AssertsSpec extends RefSpec with Checkers {
   def `scalatest asserts` =
     check(Test.testSuccess(Asserts.scalaTestAsserts _, true :: HNil))
 

--- a/src/test/scala/stdlib/ByNameParameterSpec.scala
+++ b/src/test/scala/stdlib/ByNameParameterSpec.scala
@@ -1,6 +1,6 @@
 /*
  *  scala-exercises - exercises-stdlib
- *  Copyright (C) 2015-2016 47 Degrees, LLC. <http://www.47deg.com>
+ *  Copyright (C) 2015-2019 47 Degrees, LLC. <http://www.47deg.com>
  *
  */
 
@@ -9,7 +9,7 @@ package stdlib
 import org.scalacheck.ScalacheckShapeless._
 import org.scalaexercises.Test
 import org.scalatest.refspec.RefSpec
-import org.scalatest.prop.Checkers
+import org.scalatestplus.scalacheck.Checkers
 import shapeless.HNil
 
 class ByNameParameterSpec extends RefSpec with Checkers {

--- a/src/test/scala/stdlib/ByNameParameterSpec.scala
+++ b/src/test/scala/stdlib/ByNameParameterSpec.scala
@@ -6,13 +6,13 @@
 
 package stdlib
 
-import org.scalacheck.Shapeless._
+import org.scalacheck.ScalacheckShapeless._
 import org.scalaexercises.Test
-import org.scalatest.Spec
+import org.scalatest.refspec.RefSpec
 import org.scalatest.prop.Checkers
 import shapeless.HNil
 
-class ByNameParameterSpec extends Spec with Checkers {
+class ByNameParameterSpec extends RefSpec with Checkers {
   def `takes unit by name parameter` = {
     val right: Either[Throwable, Int] = Right(29)
 

--- a/src/test/scala/stdlib/CaseClassesSpec.scala
+++ b/src/test/scala/stdlib/CaseClassesSpec.scala
@@ -6,13 +6,13 @@
 
 package stdlib
 
-import org.scalacheck.Shapeless._
+import org.scalacheck.ScalacheckShapeless._
 import org.scalaexercises.Test
-import org.scalatest.Spec
+import org.scalatest.refspec.RefSpec
 import org.scalatest.prop.Checkers
 import shapeless.HNil
 
-class CaseClassesSpec extends Spec with Checkers {
+class CaseClassesSpec extends RefSpec with Checkers {
   def `case classes comparisons` = {
     check(
       Test.testSuccess(

--- a/src/test/scala/stdlib/CaseClassesSpec.scala
+++ b/src/test/scala/stdlib/CaseClassesSpec.scala
@@ -1,6 +1,6 @@
 /*
  *  scala-exercises - exercises-stdlib
- *  Copyright (C) 2015-2016 47 Degrees, LLC. <http://www.47deg.com>
+ *  Copyright (C) 2015-2019 47 Degrees, LLC. <http://www.47deg.com>
  *
  */
 
@@ -9,7 +9,7 @@ package stdlib
 import org.scalacheck.ScalacheckShapeless._
 import org.scalaexercises.Test
 import org.scalatest.refspec.RefSpec
-import org.scalatest.prop.Checkers
+import org.scalatestplus.scalacheck.Checkers
 import shapeless.HNil
 
 class CaseClassesSpec extends RefSpec with Checkers {

--- a/src/test/scala/stdlib/ClassesSpec.scala
+++ b/src/test/scala/stdlib/ClassesSpec.scala
@@ -6,13 +6,13 @@
 
 package stdlib
 
-import org.scalacheck.Shapeless._
+import org.scalacheck.ScalacheckShapeless._
 import org.scalaexercises.Test
-import org.scalatest.Spec
+import org.scalatest.refspec.RefSpec
 import org.scalatest.prop.Checkers
 import shapeless.HNil
 
-class ClassesSpec extends Spec with Checkers {
+class ClassesSpec extends RefSpec with Checkers {
   def `classes with val parameters` = {
     check(
       Test.testSuccess(

--- a/src/test/scala/stdlib/ClassesSpec.scala
+++ b/src/test/scala/stdlib/ClassesSpec.scala
@@ -1,6 +1,6 @@
 /*
  *  scala-exercises - exercises-stdlib
- *  Copyright (C) 2015-2016 47 Degrees, LLC. <http://www.47deg.com>
+ *  Copyright (C) 2015-2019 47 Degrees, LLC. <http://www.47deg.com>
  *
  */
 
@@ -9,7 +9,7 @@ package stdlib
 import org.scalacheck.ScalacheckShapeless._
 import org.scalaexercises.Test
 import org.scalatest.refspec.RefSpec
-import org.scalatest.prop.Checkers
+import org.scalatestplus.scalacheck.Checkers
 import shapeless.HNil
 
 class ClassesSpec extends RefSpec with Checkers {

--- a/src/test/scala/stdlib/EmptyValuesSpec.scala
+++ b/src/test/scala/stdlib/EmptyValuesSpec.scala
@@ -6,13 +6,13 @@
 
 package stdlib
 
-import org.scalacheck.Shapeless._
+import org.scalacheck.ScalacheckShapeless._
 import org.scalaexercises.Test
-import org.scalatest.Spec
+import org.scalatest.refspec.RefSpec
 import org.scalatest.prop.Checkers
 import shapeless.HNil
 
-class EmptyValuesSpec extends Spec with Checkers {
+class EmptyValuesSpec extends RefSpec with Checkers {
   def `empty values` = {
     check(
       Test.testSuccess(

--- a/src/test/scala/stdlib/EmptyValuesSpec.scala
+++ b/src/test/scala/stdlib/EmptyValuesSpec.scala
@@ -1,6 +1,6 @@
 /*
  *  scala-exercises - exercises-stdlib
- *  Copyright (C) 2015-2016 47 Degrees, LLC. <http://www.47deg.com>
+ *  Copyright (C) 2015-2019 47 Degrees, LLC. <http://www.47deg.com>
  *
  */
 
@@ -9,7 +9,7 @@ package stdlib
 import org.scalacheck.ScalacheckShapeless._
 import org.scalaexercises.Test
 import org.scalatest.refspec.RefSpec
-import org.scalatest.prop.Checkers
+import org.scalatestplus.scalacheck.Checkers
 import shapeless.HNil
 
 class EmptyValuesSpec extends RefSpec with Checkers {

--- a/src/test/scala/stdlib/EnumerationsSpec.scala
+++ b/src/test/scala/stdlib/EnumerationsSpec.scala
@@ -1,7 +1,0 @@
-/*
- *  scala-exercises - exercises-stdlib
- *  Copyright (C) 2015-2016 47 Degrees, LLC. <http://www.47deg.com>
- *
- */
-
-package stdlib

--- a/src/test/scala/stdlib/ExtractorsSpec.scala
+++ b/src/test/scala/stdlib/ExtractorsSpec.scala
@@ -1,6 +1,6 @@
 /*
  *  scala-exercises - exercises-stdlib
- *  Copyright (C) 2015-2016 47 Degrees, LLC. <http://www.47deg.com>
+ *  Copyright (C) 2015-2019 47 Degrees, LLC. <http://www.47deg.com>
  *
  */
 
@@ -9,7 +9,7 @@ package stdlib
 import org.scalacheck.ScalacheckShapeless._
 import org.scalaexercises.Test
 import org.scalatest.refspec.RefSpec
-import org.scalatest.prop.Checkers
+import org.scalatestplus.scalacheck.Checkers
 import shapeless.HNil
 
 class ExtractorsSpec extends RefSpec with Checkers {

--- a/src/test/scala/stdlib/ExtractorsSpec.scala
+++ b/src/test/scala/stdlib/ExtractorsSpec.scala
@@ -6,13 +6,13 @@
 
 package stdlib
 
-import org.scalacheck.Shapeless._
+import org.scalacheck.ScalacheckShapeless._
 import org.scalaexercises.Test
-import org.scalatest.Spec
+import org.scalatest.refspec.RefSpec
 import org.scalatest.prop.Checkers
 import shapeless.HNil
 
-class ExtractorsSpec extends Spec with Checkers {
+class ExtractorsSpec extends RefSpec with Checkers {
   def `extractors` = {
     check(
       Test.testSuccess(

--- a/src/test/scala/stdlib/ForExpressionsSpec.scala
+++ b/src/test/scala/stdlib/ForExpressionsSpec.scala
@@ -1,6 +1,6 @@
 /*
  *  scala-exercises - exercises-stdlib
- *  Copyright (C) 2015-2016 47 Degrees, LLC. <http://www.47deg.com>
+ *  Copyright (C) 2015-2019 47 Degrees, LLC. <http://www.47deg.com>
  *
  */
 
@@ -9,7 +9,7 @@ package stdlib
 import org.scalacheck.ScalacheckShapeless._
 import org.scalaexercises.Test
 import org.scalatest.refspec.RefSpec
-import org.scalatest.prop.Checkers
+import org.scalatestplus.scalacheck.Checkers
 import shapeless.HNil
 
 class ForExpressionsSpec extends RefSpec with Checkers {

--- a/src/test/scala/stdlib/ForExpressionsSpec.scala
+++ b/src/test/scala/stdlib/ForExpressionsSpec.scala
@@ -6,13 +6,13 @@
 
 package stdlib
 
-import org.scalacheck.Shapeless._
+import org.scalacheck.ScalacheckShapeless._
 import org.scalaexercises.Test
-import org.scalatest.Spec
+import org.scalatest.refspec.RefSpec
 import org.scalatest.prop.Checkers
 import shapeless.HNil
 
-class ForExpressionsSpec extends Spec with Checkers {
+class ForExpressionsSpec extends RefSpec with Checkers {
 
   def `nested for expressions` = {
     check(

--- a/src/test/scala/stdlib/FormattingSpec.scala
+++ b/src/test/scala/stdlib/FormattingSpec.scala
@@ -6,13 +6,13 @@
 
 package stdlib
 
-import org.scalacheck.Shapeless._
+import org.scalacheck.ScalacheckShapeless._
 import org.scalaexercises.Test
-import org.scalatest.Spec
+import org.scalatest.refspec.RefSpec
 import org.scalatest.prop.Checkers
 import shapeless.HNil
 
-class FormattingSpec extends Spec with Checkers {
+class FormattingSpec extends RefSpec with Checkers {
   def `strings` = {
     check(
       Test.testSuccess(
@@ -35,7 +35,7 @@ class FormattingSpec extends Spec with Checkers {
     check(
       Test.testSuccess(
         Formatting.escapeSequenceFormatting _,
-        "a" :: "a" :: "\"" :: "\\" :: HNil
+        "a" :: "\"" :: "\\" :: HNil
       )
     )
   }

--- a/src/test/scala/stdlib/FormattingSpec.scala
+++ b/src/test/scala/stdlib/FormattingSpec.scala
@@ -1,6 +1,6 @@
 /*
  *  scala-exercises - exercises-stdlib
- *  Copyright (C) 2015-2016 47 Degrees, LLC. <http://www.47deg.com>
+ *  Copyright (C) 2015-2019 47 Degrees, LLC. <http://www.47deg.com>
  *
  */
 
@@ -9,7 +9,7 @@ package stdlib
 import org.scalacheck.ScalacheckShapeless._
 import org.scalaexercises.Test
 import org.scalatest.refspec.RefSpec
-import org.scalatest.prop.Checkers
+import org.scalatestplus.scalacheck.Checkers
 import shapeless.HNil
 
 class FormattingSpec extends RefSpec with Checkers {

--- a/src/test/scala/stdlib/HigherOrderFunctionsSpec.scala
+++ b/src/test/scala/stdlib/HigherOrderFunctionsSpec.scala
@@ -1,6 +1,6 @@
 /*
  *  scala-exercises - exercises-stdlib
- *  Copyright (C) 2015-2016 47 Degrees, LLC. <http://www.47deg.com>
+ *  Copyright (C) 2015-2019 47 Degrees, LLC. <http://www.47deg.com>
  *
  */
 
@@ -9,7 +9,7 @@ package stdlib
 import org.scalacheck.ScalacheckShapeless._
 import org.scalaexercises.Test
 import org.scalatest.refspec.RefSpec
-import org.scalatest.prop.Checkers
+import org.scalatestplus.scalacheck.Checkers
 import shapeless.HNil
 
 class HigherOrderFunctionsSpec extends RefSpec with Checkers {

--- a/src/test/scala/stdlib/HigherOrderFunctionsSpec.scala
+++ b/src/test/scala/stdlib/HigherOrderFunctionsSpec.scala
@@ -6,13 +6,13 @@
 
 package stdlib
 
-import org.scalacheck.Shapeless._
+import org.scalacheck.ScalacheckShapeless._
 import org.scalaexercises.Test
-import org.scalatest.Spec
+import org.scalatest.refspec.RefSpec
 import org.scalatest.prop.Checkers
 import shapeless.HNil
 
-class HigherOrderFunctionsSpec extends Spec with Checkers {
+class HigherOrderFunctionsSpec extends RefSpec with Checkers {
   def `anonymous function` = {
     check(
       Test.testSuccess(

--- a/src/test/scala/stdlib/ImplicitsSpec.scala
+++ b/src/test/scala/stdlib/ImplicitsSpec.scala
@@ -1,6 +1,6 @@
 /*
  *  scala-exercises - exercises-stdlib
- *  Copyright (C) 2015-2016 47 Degrees, LLC. <http://www.47deg.com>
+ *  Copyright (C) 2015-2019 47 Degrees, LLC. <http://www.47deg.com>
  *
  */
 
@@ -9,7 +9,7 @@ package stdlib
 import org.scalacheck.ScalacheckShapeless._
 import org.scalaexercises.Test
 import org.scalatest.refspec.RefSpec
-import org.scalatest.prop.Checkers
+import org.scalatestplus.scalacheck.Checkers
 import shapeless.HNil
 
 class ImplicitsSpec extends RefSpec with Checkers {

--- a/src/test/scala/stdlib/ImplicitsSpec.scala
+++ b/src/test/scala/stdlib/ImplicitsSpec.scala
@@ -6,13 +6,13 @@
 
 package stdlib
 
-import org.scalacheck.Shapeless._
+import org.scalacheck.ScalacheckShapeless._
 import org.scalaexercises.Test
-import org.scalatest.Spec
+import org.scalatest.refspec.RefSpec
 import org.scalatest.prop.Checkers
 import shapeless.HNil
 
-class ImplicitsSpec extends Spec with Checkers {
+class ImplicitsSpec extends RefSpec with Checkers {
   def `implicit parameters` = {
     check(
       Test.testSuccess(

--- a/src/test/scala/stdlib/InfixPrefixAndPostfixOperatorsSpec.scala
+++ b/src/test/scala/stdlib/InfixPrefixAndPostfixOperatorsSpec.scala
@@ -7,14 +7,14 @@
 package stdlib
 
 import org.scalaexercises.Test
-import org.scalatest.Spec
+import org.scalatest.refspec.RefSpec
 import org.scalatest.prop.Checkers
 import shapeless.HNil
 
 // FIXME: get rid of this if possible
-import org.scalacheck.Shapeless._
+import org.scalacheck.ScalacheckShapeless._
 
-class InfixPrefixAndPostfixOperatorsSpec extends Spec with Checkers {
+class InfixPrefixAndPostfixOperatorsSpec extends RefSpec with Checkers {
   val Operators = InfixPrefixandPostfixOperators
 
   def `single parameter infix operators` = {

--- a/src/test/scala/stdlib/InfixPrefixAndPostfixOperatorsSpec.scala
+++ b/src/test/scala/stdlib/InfixPrefixAndPostfixOperatorsSpec.scala
@@ -1,6 +1,6 @@
 /*
  *  scala-exercises - exercises-stdlib
- *  Copyright (C) 2015-2016 47 Degrees, LLC. <http://www.47deg.com>
+ *  Copyright (C) 2015-2019 47 Degrees, LLC. <http://www.47deg.com>
  *
  */
 
@@ -8,7 +8,7 @@ package stdlib
 
 import org.scalaexercises.Test
 import org.scalatest.refspec.RefSpec
-import org.scalatest.prop.Checkers
+import org.scalatestplus.scalacheck.Checkers
 import shapeless.HNil
 
 // FIXME: get rid of this if possible

--- a/src/test/scala/stdlib/InfixTypesSpec.scala
+++ b/src/test/scala/stdlib/InfixTypesSpec.scala
@@ -6,13 +6,13 @@
 
 package stdlib
 
-import org.scalacheck.Shapeless._
+import org.scalacheck.ScalacheckShapeless._
 import org.scalaexercises.Test
-import org.scalatest.Spec
+import org.scalatest.refspec.RefSpec
 import org.scalatest.prop.Checkers
 import shapeless.HNil
 
-class InfixTypesSpec extends Spec with Checkers {
+class InfixTypesSpec extends RefSpec with Checkers {
   def `infix type` = {
     check(
       Test.testSuccess(

--- a/src/test/scala/stdlib/InfixTypesSpec.scala
+++ b/src/test/scala/stdlib/InfixTypesSpec.scala
@@ -1,6 +1,6 @@
 /*
  *  scala-exercises - exercises-stdlib
- *  Copyright (C) 2015-2016 47 Degrees, LLC. <http://www.47deg.com>
+ *  Copyright (C) 2015-2019 47 Degrees, LLC. <http://www.47deg.com>
  *
  */
 
@@ -9,7 +9,7 @@ package stdlib
 import org.scalacheck.ScalacheckShapeless._
 import org.scalaexercises.Test
 import org.scalatest.refspec.RefSpec
-import org.scalatest.prop.Checkers
+import org.scalatestplus.scalacheck.Checkers
 import shapeless.HNil
 
 class InfixTypesSpec extends RefSpec with Checkers {

--- a/src/test/scala/stdlib/IterablesSpec.scala
+++ b/src/test/scala/stdlib/IterablesSpec.scala
@@ -1,6 +1,6 @@
 /*
  *  scala-exercises - exercises-stdlib
- *  Copyright (C) 2015-2016 47 Degrees, LLC. <http://www.47deg.com>
+ *  Copyright (C) 2015-2019 47 Degrees, LLC. <http://www.47deg.com>
  *
  */
 
@@ -9,7 +9,7 @@ package stdlib
 import org.scalacheck.ScalacheckShapeless._
 import org.scalaexercises.Test
 import org.scalatest.refspec.RefSpec
-import org.scalatest.prop.Checkers
+import org.scalatestplus.scalacheck.Checkers
 import shapeless.HNil
 
 class IterablesSpec extends RefSpec with Checkers {

--- a/src/test/scala/stdlib/IterablesSpec.scala
+++ b/src/test/scala/stdlib/IterablesSpec.scala
@@ -6,13 +6,13 @@
 
 package stdlib
 
-import org.scalacheck.Shapeless._
+import org.scalacheck.ScalacheckShapeless._
 import org.scalaexercises.Test
-import org.scalatest.Spec
+import org.scalatest.refspec.RefSpec
 import org.scalatest.prop.Checkers
 import shapeless.HNil
 
-class IterablesSpec extends Spec with Checkers {
+class IterablesSpec extends RefSpec with Checkers {
   def `collection iterables` = {
     check(
       Test.testSuccess(

--- a/src/test/scala/stdlib/ListsSpec.scala
+++ b/src/test/scala/stdlib/ListsSpec.scala
@@ -1,6 +1,6 @@
 /*
  *  scala-exercises - exercises-stdlib
- *  Copyright (C) 2015-2016 47 Degrees, LLC. <http://www.47deg.com>
+ *  Copyright (C) 2015-2019 47 Degrees, LLC. <http://www.47deg.com>
  *
  */
 
@@ -9,7 +9,7 @@ package stdlib
 import org.scalacheck.ScalacheckShapeless._
 import org.scalaexercises.Test
 import org.scalatest.refspec.RefSpec
-import org.scalatest.prop.Checkers
+import org.scalatestplus.scalacheck.Checkers
 import shapeless.HNil
 
 class ListsSpec extends RefSpec with Checkers {

--- a/src/test/scala/stdlib/ListsSpec.scala
+++ b/src/test/scala/stdlib/ListsSpec.scala
@@ -6,13 +6,13 @@
 
 package stdlib
 
-import org.scalacheck.Shapeless._
+import org.scalacheck.ScalacheckShapeless._
 import org.scalaexercises.Test
-import org.scalatest.Spec
+import org.scalatest.refspec.RefSpec
 import org.scalatest.prop.Checkers
 import shapeless.HNil
 
-class ListsSpec extends Spec with Checkers {
+class ListsSpec extends RefSpec with Checkers {
   def `are homogeneous` = {
     check(
       Test.testSuccess(

--- a/src/test/scala/stdlib/LiteralBooleansSpec.scala
+++ b/src/test/scala/stdlib/LiteralBooleansSpec.scala
@@ -6,13 +6,13 @@
 
 package stdlib
 
-import org.scalacheck.Shapeless._
+import org.scalacheck.ScalacheckShapeless._
 import org.scalaexercises.Test
-import org.scalatest.Spec
+import org.scalatest.refspec.RefSpec
 import org.scalatest.prop.Checkers
 import shapeless.HNil
 
-class LiteralBooleansSpec extends Spec with Checkers {
+class LiteralBooleansSpec extends RefSpec with Checkers {
   def `are either true or false` = {
     check(
       Test.testSuccess(

--- a/src/test/scala/stdlib/LiteralBooleansSpec.scala
+++ b/src/test/scala/stdlib/LiteralBooleansSpec.scala
@@ -1,6 +1,6 @@
 /*
  *  scala-exercises - exercises-stdlib
- *  Copyright (C) 2015-2016 47 Degrees, LLC. <http://www.47deg.com>
+ *  Copyright (C) 2015-2019 47 Degrees, LLC. <http://www.47deg.com>
  *
  */
 
@@ -9,7 +9,7 @@ package stdlib
 import org.scalacheck.ScalacheckShapeless._
 import org.scalaexercises.Test
 import org.scalatest.refspec.RefSpec
-import org.scalatest.prop.Checkers
+import org.scalatestplus.scalacheck.Checkers
 import shapeless.HNil
 
 class LiteralBooleansSpec extends RefSpec with Checkers {

--- a/src/test/scala/stdlib/LiteralNumbersSpec.scala
+++ b/src/test/scala/stdlib/LiteralNumbersSpec.scala
@@ -1,6 +1,6 @@
 /*
  *  scala-exercises - exercises-stdlib
- *  Copyright (C) 2015-2016 47 Degrees, LLC. <http://www.47deg.com>
+ *  Copyright (C) 2015-2019 47 Degrees, LLC. <http://www.47deg.com>
  *
  */
 
@@ -9,7 +9,7 @@ package stdlib
 import org.scalacheck.ScalacheckShapeless._
 import org.scalaexercises.Test
 import org.scalatest.refspec.RefSpec
-import org.scalatest.prop.Checkers
+import org.scalatestplus.scalacheck.Checkers
 import shapeless.HNil
 
 class LiteralNumbersSpec extends RefSpec with Checkers {

--- a/src/test/scala/stdlib/LiteralNumbersSpec.scala
+++ b/src/test/scala/stdlib/LiteralNumbersSpec.scala
@@ -6,13 +6,13 @@
 
 package stdlib
 
-import org.scalacheck.Shapeless._
+import org.scalacheck.ScalacheckShapeless._
 import org.scalaexercises.Test
-import org.scalatest.Spec
+import org.scalatest.refspec.RefSpec
 import org.scalatest.prop.Checkers
 import shapeless.HNil
 
-class LiteralNumbersSpec extends Spec with Checkers {
+class LiteralNumbersSpec extends RefSpec with Checkers {
   def `integer literals` = {
     check(
       Test.testSuccess(

--- a/src/test/scala/stdlib/LiteralStringsSpec.scala
+++ b/src/test/scala/stdlib/LiteralStringsSpec.scala
@@ -6,13 +6,13 @@
 
 package stdlib
 
-import org.scalacheck.Shapeless._
+import org.scalacheck.ScalacheckShapeless._
 import org.scalaexercises.Test
-import org.scalatest.Spec
+import org.scalatest.refspec.RefSpec
 import org.scalatest.prop.Checkers
 import shapeless.HNil
 
-class LiteralStringsSpec extends Spec with Checkers {
+class LiteralStringsSpec extends RefSpec with Checkers {
   def `character literals` = {
     check(
       Test.testSuccess(
@@ -26,15 +26,6 @@ class LiteralStringsSpec extends Spec with Checkers {
     check(
       Test.testSuccess(
         LiteralStrings.characterLiteralsUnicodeLiteralStrings _,
-        "a" :: HNil
-      )
-    )
-  }
-
-  def `octal character literals` = {
-    check(
-      Test.testSuccess(
-        LiteralStrings.characterLiteralsOctalLiteralStrings _,
         "a" :: HNil
       )
     )

--- a/src/test/scala/stdlib/LiteralStringsSpec.scala
+++ b/src/test/scala/stdlib/LiteralStringsSpec.scala
@@ -1,6 +1,6 @@
 /*
  *  scala-exercises - exercises-stdlib
- *  Copyright (C) 2015-2016 47 Degrees, LLC. <http://www.47deg.com>
+ *  Copyright (C) 2015-2019 47 Degrees, LLC. <http://www.47deg.com>
  *
  */
 
@@ -9,7 +9,7 @@ package stdlib
 import org.scalacheck.ScalacheckShapeless._
 import org.scalaexercises.Test
 import org.scalatest.refspec.RefSpec
-import org.scalatest.prop.Checkers
+import org.scalatestplus.scalacheck.Checkers
 import shapeless.HNil
 
 class LiteralStringsSpec extends RefSpec with Checkers {

--- a/src/test/scala/stdlib/MapsSpec.scala
+++ b/src/test/scala/stdlib/MapsSpec.scala
@@ -6,13 +6,13 @@
 
 package stdlib
 
-import org.scalacheck.Shapeless._
+import org.scalacheck.ScalacheckShapeless._
 import org.scalaexercises.Test
-import org.scalatest.Spec
+import org.scalatest.refspec.RefSpec
 import org.scalatest.prop.Checkers
 import shapeless.HNil
 
-class MapsSpec extends Spec with Checkers {
+class MapsSpec extends RefSpec with Checkers {
   def `size` = {
     check(
       Test.testSuccess(

--- a/src/test/scala/stdlib/MapsSpec.scala
+++ b/src/test/scala/stdlib/MapsSpec.scala
@@ -1,6 +1,6 @@
 /*
  *  scala-exercises - exercises-stdlib
- *  Copyright (C) 2015-2016 47 Degrees, LLC. <http://www.47deg.com>
+ *  Copyright (C) 2015-2019 47 Degrees, LLC. <http://www.47deg.com>
  *
  */
 
@@ -9,7 +9,7 @@ package stdlib
 import org.scalacheck.ScalacheckShapeless._
 import org.scalaexercises.Test
 import org.scalatest.refspec.RefSpec
-import org.scalatest.prop.Checkers
+import org.scalatestplus.scalacheck.Checkers
 import shapeless.HNil
 
 class MapsSpec extends RefSpec with Checkers {

--- a/src/test/scala/stdlib/NamedAndDefaultArgumentsSpec.scala
+++ b/src/test/scala/stdlib/NamedAndDefaultArgumentsSpec.scala
@@ -6,13 +6,13 @@
 
 package stdlib
 
-import org.scalacheck.Shapeless._
+import org.scalacheck.ScalacheckShapeless._
 import org.scalaexercises.Test
-import org.scalatest.Spec
+import org.scalatest.refspec.RefSpec
 import org.scalatest.prop.Checkers
 import shapeless.HNil
 
-class NamedAndDefaultArgumentsSpec extends Spec with Checkers {
+class NamedAndDefaultArgumentsSpec extends RefSpec with Checkers {
   val Arguments = NamedandDefaultArguments
 
   def `class without parameters` = {

--- a/src/test/scala/stdlib/NamedAndDefaultArgumentsSpec.scala
+++ b/src/test/scala/stdlib/NamedAndDefaultArgumentsSpec.scala
@@ -1,6 +1,6 @@
 /*
  *  scala-exercises - exercises-stdlib
- *  Copyright (C) 2015-2016 47 Degrees, LLC. <http://www.47deg.com>
+ *  Copyright (C) 2015-2019 47 Degrees, LLC. <http://www.47deg.com>
  *
  */
 
@@ -9,7 +9,7 @@ package stdlib
 import org.scalacheck.ScalacheckShapeless._
 import org.scalaexercises.Test
 import org.scalatest.refspec.RefSpec
-import org.scalatest.prop.Checkers
+import org.scalatestplus.scalacheck.Checkers
 import shapeless.HNil
 
 class NamedAndDefaultArgumentsSpec extends RefSpec with Checkers {

--- a/src/test/scala/stdlib/ObjectsSpec.scala
+++ b/src/test/scala/stdlib/ObjectsSpec.scala
@@ -6,13 +6,13 @@
 
 package stdlib
 
-import org.scalacheck.Shapeless._
+import org.scalacheck.ScalacheckShapeless._
 import org.scalaexercises.Test
-import org.scalatest.Spec
+import org.scalatest.refspec.RefSpec
 import org.scalatest.prop.Checkers
 import shapeless.HNil
 
-class ObjectsSpec extends Spec with Checkers {
+class ObjectsSpec extends RefSpec with Checkers {
   def `singleton` = {
     check(
       Test.testSuccess(

--- a/src/test/scala/stdlib/ObjectsSpec.scala
+++ b/src/test/scala/stdlib/ObjectsSpec.scala
@@ -1,6 +1,6 @@
 /*
  *  scala-exercises - exercises-stdlib
- *  Copyright (C) 2015-2016 47 Degrees, LLC. <http://www.47deg.com>
+ *  Copyright (C) 2015-2019 47 Degrees, LLC. <http://www.47deg.com>
  *
  */
 
@@ -9,7 +9,7 @@ package stdlib
 import org.scalacheck.ScalacheckShapeless._
 import org.scalaexercises.Test
 import org.scalatest.refspec.RefSpec
-import org.scalatest.prop.Checkers
+import org.scalatestplus.scalacheck.Checkers
 import shapeless.HNil
 
 class ObjectsSpec extends RefSpec with Checkers {

--- a/src/test/scala/stdlib/OptionsSpec.scala
+++ b/src/test/scala/stdlib/OptionsSpec.scala
@@ -6,13 +6,13 @@
 
 package stdlib
 
-import org.scalacheck.Shapeless._
+import org.scalacheck.ScalacheckShapeless._
 import org.scalaexercises.Test
-import org.scalatest.Spec
+import org.scalatest.refspec.RefSpec
 import org.scalatest.prop.Checkers
 import shapeless.HNil
 
-class OptionsSpec extends Spec with Checkers {
+class OptionsSpec extends RefSpec with Checkers {
   def `none and some` = {
     val theNone: Option[String] = None
 

--- a/src/test/scala/stdlib/OptionsSpec.scala
+++ b/src/test/scala/stdlib/OptionsSpec.scala
@@ -1,6 +1,6 @@
 /*
  *  scala-exercises - exercises-stdlib
- *  Copyright (C) 2015-2016 47 Degrees, LLC. <http://www.47deg.com>
+ *  Copyright (C) 2015-2019 47 Degrees, LLC. <http://www.47deg.com>
  *
  */
 
@@ -9,7 +9,7 @@ package stdlib
 import org.scalacheck.ScalacheckShapeless._
 import org.scalaexercises.Test
 import org.scalatest.refspec.RefSpec
-import org.scalatest.prop.Checkers
+import org.scalatestplus.scalacheck.Checkers
 import shapeless.HNil
 
 class OptionsSpec extends RefSpec with Checkers {

--- a/src/test/scala/stdlib/ParentClassesSpec.scala
+++ b/src/test/scala/stdlib/ParentClassesSpec.scala
@@ -6,13 +6,13 @@
 
 package stdlib
 
-import org.scalacheck.Shapeless._
+import org.scalacheck.ScalacheckShapeless._
 import org.scalaexercises.Test
-import org.scalatest.Spec
+import org.scalatest.refspec.RefSpec
 import org.scalatest.prop.Checkers
 import shapeless.HNil
 
-class ParentClassesSpec extends Spec with Checkers {
+class ParentClassesSpec extends RefSpec with Checkers {
   def `all values are objects` = {
     check(
       Test.testSuccess(

--- a/src/test/scala/stdlib/ParentClassesSpec.scala
+++ b/src/test/scala/stdlib/ParentClassesSpec.scala
@@ -1,6 +1,6 @@
 /*
  *  scala-exercises - exercises-stdlib
- *  Copyright (C) 2015-2016 47 Degrees, LLC. <http://www.47deg.com>
+ *  Copyright (C) 2015-2019 47 Degrees, LLC. <http://www.47deg.com>
  *
  */
 
@@ -9,7 +9,7 @@ package stdlib
 import org.scalacheck.ScalacheckShapeless._
 import org.scalaexercises.Test
 import org.scalatest.refspec.RefSpec
-import org.scalatest.prop.Checkers
+import org.scalatestplus.scalacheck.Checkers
 import shapeless.HNil
 
 class ParentClassesSpec extends RefSpec with Checkers {

--- a/src/test/scala/stdlib/PartialFunctionsSpec.scala
+++ b/src/test/scala/stdlib/PartialFunctionsSpec.scala
@@ -6,13 +6,13 @@
 
 package stdlib
 
-import org.scalacheck.Shapeless._
+import org.scalacheck.ScalacheckShapeless._
 import org.scalaexercises.Test
-import org.scalatest.Spec
+import org.scalatest.refspec.RefSpec
 import org.scalatest.prop.Checkers
 import shapeless.HNil
 
-class PartialFunctionsSpec extends Spec with Checkers {
+class PartialFunctionsSpec extends RefSpec with Checkers {
   def `partial functions` = {
     check(
       Test.testSuccess(

--- a/src/test/scala/stdlib/PartialFunctionsSpec.scala
+++ b/src/test/scala/stdlib/PartialFunctionsSpec.scala
@@ -1,6 +1,6 @@
 /*
  *  scala-exercises - exercises-stdlib
- *  Copyright (C) 2015-2016 47 Degrees, LLC. <http://www.47deg.com>
+ *  Copyright (C) 2015-2019 47 Degrees, LLC. <http://www.47deg.com>
  *
  */
 
@@ -9,7 +9,7 @@ package stdlib
 import org.scalacheck.ScalacheckShapeless._
 import org.scalaexercises.Test
 import org.scalatest.refspec.RefSpec
-import org.scalatest.prop.Checkers
+import org.scalatestplus.scalacheck.Checkers
 import shapeless.HNil
 
 class PartialFunctionsSpec extends RefSpec with Checkers {

--- a/src/test/scala/stdlib/PartiallyAppliedFunctionsSpec.scala
+++ b/src/test/scala/stdlib/PartiallyAppliedFunctionsSpec.scala
@@ -1,6 +1,6 @@
 /*
  *  scala-exercises - exercises-stdlib
- *  Copyright (C) 2015-2016 47 Degrees, LLC. <http://www.47deg.com>
+ *  Copyright (C) 2015-2019 47 Degrees, LLC. <http://www.47deg.com>
  *
  */
 
@@ -9,7 +9,7 @@ package stdlib
 import org.scalacheck.ScalacheckShapeless._
 import org.scalaexercises.Test
 import org.scalatest.refspec.RefSpec
-import org.scalatest.prop.Checkers
+import org.scalatestplus.scalacheck.Checkers
 import shapeless.HNil
 
 class PartiallyAppliedFunctionsSpec extends RefSpec with Checkers {

--- a/src/test/scala/stdlib/PartiallyAppliedFunctionsSpec.scala
+++ b/src/test/scala/stdlib/PartiallyAppliedFunctionsSpec.scala
@@ -6,13 +6,13 @@
 
 package stdlib
 
-import org.scalacheck.Shapeless._
+import org.scalacheck.ScalacheckShapeless._
 import org.scalaexercises.Test
-import org.scalatest.Spec
+import org.scalatest.refspec.RefSpec
 import org.scalatest.prop.Checkers
 import shapeless.HNil
 
-class PartiallyAppliedFunctionsSpec extends Spec with Checkers {
+class PartiallyAppliedFunctionsSpec extends RefSpec with Checkers {
   def `partially applied functions` = {
     check(
       Test.testSuccess(

--- a/src/test/scala/stdlib/PatternMatchingSpec.scala
+++ b/src/test/scala/stdlib/PatternMatchingSpec.scala
@@ -1,6 +1,6 @@
 /*
  *  scala-exercises - exercises-stdlib
- *  Copyright (C) 2015-2016 47 Degrees, LLC. <http://www.47deg.com>
+ *  Copyright (C) 2015-2019 47 Degrees, LLC. <http://www.47deg.com>
  *
  */
 
@@ -9,7 +9,7 @@ package stdlib
 import org.scalacheck.ScalacheckShapeless._
 import org.scalaexercises.Test
 import org.scalatest.refspec.RefSpec
-import org.scalatest.prop.Checkers
+import org.scalatestplus.scalacheck.Checkers
 import shapeless.HNil
 
 class PatternMatchingSpec extends RefSpec with Checkers {

--- a/src/test/scala/stdlib/PatternMatchingSpec.scala
+++ b/src/test/scala/stdlib/PatternMatchingSpec.scala
@@ -6,13 +6,13 @@
 
 package stdlib
 
-import org.scalacheck.Shapeless._
+import org.scalacheck.ScalacheckShapeless._
 import org.scalaexercises.Test
-import org.scalatest.Spec
+import org.scalatest.refspec.RefSpec
 import org.scalatest.prop.Checkers
 import shapeless.HNil
 
-class PatternMatchingSpec extends Spec with Checkers {
+class PatternMatchingSpec extends RefSpec with Checkers {
   def `pattern matching` = {
     check(
       Test.testSuccess(

--- a/src/test/scala/stdlib/RangesSpec.scala
+++ b/src/test/scala/stdlib/RangesSpec.scala
@@ -1,6 +1,6 @@
 /*
  *  scala-exercises - exercises-stdlib
- *  Copyright (C) 2015-2016 47 Degrees, LLC. <http://www.47deg.com>
+ *  Copyright (C) 2015-2019 47 Degrees, LLC. <http://www.47deg.com>
  *
  */
 
@@ -9,7 +9,7 @@ package stdlib
 import org.scalacheck.ScalacheckShapeless._
 import org.scalaexercises.Test
 import org.scalatest.refspec.RefSpec
-import org.scalatest.prop.Checkers
+import org.scalatestplus.scalacheck.Checkers
 import shapeless.HNil
 
 class RangesSpec extends RefSpec with Checkers {

--- a/src/test/scala/stdlib/RangesSpec.scala
+++ b/src/test/scala/stdlib/RangesSpec.scala
@@ -6,13 +6,13 @@
 
 package stdlib
 
-import org.scalacheck.Shapeless._
+import org.scalacheck.ScalacheckShapeless._
 import org.scalaexercises.Test
-import org.scalatest.Spec
+import org.scalatest.refspec.RefSpec
 import org.scalatest.prop.Checkers
 import shapeless.HNil
 
-class RangesSpec extends Spec with Checkers {
+class RangesSpec extends RefSpec with Checkers {
   def `upper bounds are not inclusive` = {
     check(
       Test.testSuccess(

--- a/src/test/scala/stdlib/RepeatedParametersSpec.scala
+++ b/src/test/scala/stdlib/RepeatedParametersSpec.scala
@@ -1,6 +1,6 @@
 /*
  *  scala-exercises - exercises-stdlib
- *  Copyright (C) 2015-2016 47 Degrees, LLC. <http://www.47deg.com>
+ *  Copyright (C) 2015-2019 47 Degrees, LLC. <http://www.47deg.com>
  *
  */
 
@@ -9,7 +9,7 @@ package stdlib
 import org.scalacheck.ScalacheckShapeless._
 import org.scalaexercises.Test
 import org.scalatest.refspec.RefSpec
-import org.scalatest.prop.Checkers
+import org.scalatestplus.scalacheck.Checkers
 import shapeless.HNil
 
 class RepeatedParametersSpec extends RefSpec with Checkers {

--- a/src/test/scala/stdlib/RepeatedParametersSpec.scala
+++ b/src/test/scala/stdlib/RepeatedParametersSpec.scala
@@ -6,13 +6,13 @@
 
 package stdlib
 
-import org.scalacheck.Shapeless._
+import org.scalacheck.ScalacheckShapeless._
 import org.scalaexercises.Test
-import org.scalatest.Spec
+import org.scalatest.refspec.RefSpec
 import org.scalatest.prop.Checkers
 import shapeless.HNil
 
-class RepeatedParametersSpec extends Spec with Checkers {
+class RepeatedParametersSpec extends RefSpec with Checkers {
   def `multiple last parameters` = {
     check(
       Test.testSuccess(

--- a/src/test/scala/stdlib/SequencesAndArraysSpec.scala
+++ b/src/test/scala/stdlib/SequencesAndArraysSpec.scala
@@ -6,13 +6,13 @@
 
 package stdlib
 
-import org.scalacheck.Shapeless._
+import org.scalacheck.ScalacheckShapeless._
 import org.scalaexercises.Test
-import org.scalatest.Spec
+import org.scalatest.refspec.RefSpec
 import org.scalatest.prop.Checkers
 import shapeless.HNil
 
-class SequencesAndArraysSpec extends Spec with Checkers {
+class SequencesAndArraysSpec extends RefSpec with Checkers {
   def `list to array` = {
     check(
       Test.testSuccess(

--- a/src/test/scala/stdlib/SequencesAndArraysSpec.scala
+++ b/src/test/scala/stdlib/SequencesAndArraysSpec.scala
@@ -1,6 +1,6 @@
 /*
  *  scala-exercises - exercises-stdlib
- *  Copyright (C) 2015-2016 47 Degrees, LLC. <http://www.47deg.com>
+ *  Copyright (C) 2015-2019 47 Degrees, LLC. <http://www.47deg.com>
  *
  */
 
@@ -9,7 +9,7 @@ package stdlib
 import org.scalacheck.ScalacheckShapeless._
 import org.scalaexercises.Test
 import org.scalatest.refspec.RefSpec
-import org.scalatest.prop.Checkers
+import org.scalatestplus.scalacheck.Checkers
 import shapeless.HNil
 
 class SequencesAndArraysSpec extends RefSpec with Checkers {

--- a/src/test/scala/stdlib/SetsSpec.scala
+++ b/src/test/scala/stdlib/SetsSpec.scala
@@ -6,13 +6,13 @@
 
 package stdlib
 
-import org.scalacheck.Shapeless._
+import org.scalacheck.ScalacheckShapeless._
 import org.scalaexercises.Test
-import org.scalatest.Spec
+import org.scalatest.refspec.RefSpec
 import org.scalatest.prop.Checkers
 import shapeless.HNil
 
-class SetsSpec extends Spec with Checkers {
+class SetsSpec extends RefSpec with Checkers {
   def `have no duplicates` = {
     check(
       Test.testSuccess(

--- a/src/test/scala/stdlib/SetsSpec.scala
+++ b/src/test/scala/stdlib/SetsSpec.scala
@@ -1,6 +1,6 @@
 /*
  *  scala-exercises - exercises-stdlib
- *  Copyright (C) 2015-2016 47 Degrees, LLC. <http://www.47deg.com>
+ *  Copyright (C) 2015-2019 47 Degrees, LLC. <http://www.47deg.com>
  *
  */
 
@@ -9,7 +9,7 @@ package stdlib
 import org.scalacheck.ScalacheckShapeless._
 import org.scalaexercises.Test
 import org.scalatest.refspec.RefSpec
-import org.scalatest.prop.Checkers
+import org.scalatestplus.scalacheck.Checkers
 import shapeless.HNil
 
 class SetsSpec extends RefSpec with Checkers {

--- a/src/test/scala/stdlib/TraitsSpec.scala
+++ b/src/test/scala/stdlib/TraitsSpec.scala
@@ -1,6 +1,6 @@
 /*
  *  scala-exercises - exercises-stdlib
- *  Copyright (C) 2015-2016 47 Degrees, LLC. <http://www.47deg.com>
+ *  Copyright (C) 2015-2019 47 Degrees, LLC. <http://www.47deg.com>
  *
  */
 
@@ -9,7 +9,7 @@ package stdlib
 import org.scalacheck.ScalacheckShapeless._
 import org.scalaexercises.Test
 import org.scalatest.refspec.RefSpec
-import org.scalatest.prop.Checkers
+import org.scalatestplus.scalacheck.Checkers
 import shapeless.HNil
 
 class TraitsSpec extends RefSpec with Checkers {

--- a/src/test/scala/stdlib/TraitsSpec.scala
+++ b/src/test/scala/stdlib/TraitsSpec.scala
@@ -6,13 +6,13 @@
 
 package stdlib
 
-import org.scalacheck.Shapeless._
+import org.scalacheck.ScalacheckShapeless._
 import org.scalaexercises.Test
-import org.scalatest.Spec
+import org.scalatest.refspec.RefSpec
 import org.scalatest.prop.Checkers
 import shapeless.HNil
 
-class TraitsSpec extends Spec with Checkers {
+class TraitsSpec extends RefSpec with Checkers {
   def `are similar to interfaces` = {
     check(
       Test.testSuccess(

--- a/src/test/scala/stdlib/TraversablesSpec.scala
+++ b/src/test/scala/stdlib/TraversablesSpec.scala
@@ -1,6 +1,6 @@
 /*
  *  scala-exercises - exercises-stdlib
- *  Copyright (C) 2015-2016 47 Degrees, LLC. <http://www.47deg.com>
+ *  Copyright (C) 2015-2019 47 Degrees, LLC. <http://www.47deg.com>
  *
  */
 
@@ -9,7 +9,7 @@ package stdlib
 import org.scalacheck.ScalacheckShapeless._
 import org.scalaexercises.Test
 import org.scalatest.refspec.RefSpec
-import org.scalatest.prop.Checkers
+import org.scalatestplus.scalacheck.Checkers
 import shapeless.HNil
 
 class TraversablesSpec extends RefSpec with Checkers {

--- a/src/test/scala/stdlib/TraversablesSpec.scala
+++ b/src/test/scala/stdlib/TraversablesSpec.scala
@@ -6,13 +6,13 @@
 
 package stdlib
 
-import org.scalacheck.Shapeless._
+import org.scalacheck.ScalacheckShapeless._
 import org.scalaexercises.Test
-import org.scalatest.Spec
+import org.scalatest.refspec.RefSpec
 import org.scalatest.prop.Checkers
 import shapeless.HNil
 
-class TraversablesSpec extends Spec with Checkers {
+class TraversablesSpec extends RefSpec with Checkers {
   def `are at the top of collection hierarchy` = {
     check(
       Test.testSuccess(
@@ -401,7 +401,7 @@ class TraversablesSpec extends Spec with Checkers {
     check(
       Test.testSuccess(
         Traversables.foldLeftFunctionTraversables _,
-        -15 :: -15 :: -15 :: -15 :: -15 :: HNil
+        -15 :: -15 :: -15 :: HNil
       )
     )
   }
@@ -410,7 +410,7 @@ class TraversablesSpec extends Spec with Checkers {
     check(
       Test.testSuccess(
         Traversables.foldRightFunctionTraversables _,
-        3 :: 3 :: 3 :: 3 :: 3 :: HNil
+        3 :: 3 :: 3 :: HNil
       )
     )
   }

--- a/src/test/scala/stdlib/TuplesSpec.scala
+++ b/src/test/scala/stdlib/TuplesSpec.scala
@@ -1,6 +1,6 @@
 /*
  *  scala-exercises - exercises-stdlib
- *  Copyright (C) 2015-2016 47 Degrees, LLC. <http://www.47deg.com>
+ *  Copyright (C) 2015-2019 47 Degrees, LLC. <http://www.47deg.com>
  *
  */
 
@@ -9,7 +9,7 @@ package stdlib
 import org.scalacheck.ScalacheckShapeless._
 import org.scalaexercises.Test
 import org.scalatest.refspec.RefSpec
-import org.scalatest.prop.Checkers
+import org.scalatestplus.scalacheck.Checkers
 import shapeless.HNil
 
 class TuplesSpec extends RefSpec with Checkers {

--- a/src/test/scala/stdlib/TuplesSpec.scala
+++ b/src/test/scala/stdlib/TuplesSpec.scala
@@ -6,13 +6,13 @@
 
 package stdlib
 
-import org.scalacheck.Shapeless._
+import org.scalacheck.ScalacheckShapeless._
 import org.scalaexercises.Test
-import org.scalatest.Spec
+import org.scalatest.refspec.RefSpec
 import org.scalatest.prop.Checkers
 import shapeless.HNil
 
-class TuplesSpec extends Spec with Checkers {
+class TuplesSpec extends RefSpec with Checkers {
   def `are indexed` = {
     check(
       Test.testSuccess(

--- a/src/test/scala/stdlib/TypeSignaturesSpec.scala
+++ b/src/test/scala/stdlib/TypeSignaturesSpec.scala
@@ -1,6 +1,6 @@
 /*
  *  scala-exercises - exercises-stdlib
- *  Copyright (C) 2015-2016 47 Degrees, LLC. <http://www.47deg.com>
+ *  Copyright (C) 2015-2019 47 Degrees, LLC. <http://www.47deg.com>
  *
  */
 
@@ -9,7 +9,7 @@ package stdlib
 import org.scalacheck.ScalacheckShapeless._
 import org.scalaexercises.Test
 import org.scalatest.refspec.RefSpec
-import org.scalatest.prop.Checkers
+import org.scalatestplus.scalacheck.Checkers
 import shapeless.HNil
 
 class TypeSignaturesSpec extends RefSpec with Checkers {

--- a/src/test/scala/stdlib/TypeSignaturesSpec.scala
+++ b/src/test/scala/stdlib/TypeSignaturesSpec.scala
@@ -6,13 +6,13 @@
 
 package stdlib
 
-import org.scalacheck.Shapeless._
+import org.scalacheck.ScalacheckShapeless._
 import org.scalaexercises.Test
-import org.scalatest.Spec
+import org.scalatest.refspec.RefSpec
 import org.scalatest.prop.Checkers
 import shapeless.HNil
 
-class TypeSignaturesSpec extends Spec with Checkers {
+class TypeSignaturesSpec extends RefSpec with Checkers {
   def `type signatures` = {
     check(
       Test.testSuccess(

--- a/src/test/scala/stdlib/TypeVarianceSpec.scala
+++ b/src/test/scala/stdlib/TypeVarianceSpec.scala
@@ -1,6 +1,6 @@
 /*
  *  scala-exercises - exercises-stdlib
- *  Copyright (C) 2015-2016 47 Degrees, LLC. <http://www.47deg.com>
+ *  Copyright (C) 2015-2019 47 Degrees, LLC. <http://www.47deg.com>
  *
  */
 
@@ -9,7 +9,7 @@ package stdlib
 import org.scalacheck.ScalacheckShapeless._
 import org.scalaexercises.Test
 import org.scalatest.refspec.RefSpec
-import org.scalatest.prop.Checkers
+import org.scalatestplus.scalacheck.Checkers
 import shapeless.HNil
 
 class TypeVarianceSpec extends RefSpec with Checkers {

--- a/src/test/scala/stdlib/TypeVarianceSpec.scala
+++ b/src/test/scala/stdlib/TypeVarianceSpec.scala
@@ -6,13 +6,13 @@
 
 package stdlib
 
-import org.scalacheck.Shapeless._
+import org.scalacheck.ScalacheckShapeless._
 import org.scalaexercises.Test
-import org.scalatest.Spec
+import org.scalatest.refspec.RefSpec
 import org.scalatest.prop.Checkers
 import shapeless.HNil
 
-class TypeVarianceSpec extends Spec with Checkers {
+class TypeVarianceSpec extends RefSpec with Checkers {
   def `type variance` = {
     check(
       Test.testSuccess(

--- a/src/test/scala/stdlib/UniformAccessPrincipleSpec.scala
+++ b/src/test/scala/stdlib/UniformAccessPrincipleSpec.scala
@@ -1,6 +1,6 @@
 /*
  *  scala-exercises - exercises-stdlib
- *  Copyright (C) 2015-2016 47 Degrees, LLC. <http://www.47deg.com>
+ *  Copyright (C) 2015-2019 47 Degrees, LLC. <http://www.47deg.com>
  *
  */
 
@@ -9,7 +9,7 @@ package stdlib
 import org.scalacheck.ScalacheckShapeless._
 import org.scalaexercises.Test
 import org.scalatest.refspec.RefSpec
-import org.scalatest.prop.Checkers
+import org.scalatestplus.scalacheck.Checkers
 import shapeless.HNil
 
 class UniformAccessPrincipleSpec extends RefSpec with Checkers {

--- a/src/test/scala/stdlib/UniformAccessPrincipleSpec.scala
+++ b/src/test/scala/stdlib/UniformAccessPrincipleSpec.scala
@@ -6,13 +6,13 @@
 
 package stdlib
 
-import org.scalacheck.Shapeless._
+import org.scalacheck.ScalacheckShapeless._
 import org.scalaexercises.Test
-import org.scalatest.Spec
+import org.scalatest.refspec.RefSpec
 import org.scalatest.prop.Checkers
 import shapeless.HNil
 
-class UniformAccessPrincipleSpec extends Spec with Checkers {
+class UniformAccessPrincipleSpec extends RefSpec with Checkers {
   def `uniform access principle` = {
     check(
       Test.testSuccess(


### PR DESCRIPTION
This PR removes deprecation warnings from older exercises and libraries. There's still compiler warnings because of the design of the exercise. Explicitly added versions for the libraries required in the project.