### PR TITLE
Make it more clear that Scala tuple indexing starts from 1

### DIFF
--- a/src/main/scala/stdlib/Tuples.scala
+++ b/src/main/scala/stdlib/Tuples.scala
@@ -16,7 +16,7 @@ import org.scalatest.matchers.should.Matchers
  */
 object Tuples extends AnyFlatSpec with Matchers with org.scalaexercises.definitions.Section {
 
-  /** Scala tuple combines a fixed number of items together so that they can be passed around as a whole. They are one-indexed. Unlike an array or list, a tuple can hold objects with different types but they are also immutable. Here is an example of a tuple holding an integer, a string, and the console:
+  /** Scala tuple combines a fixed number of items together so that they can be passed around as a whole. They are one-indexed. Unlike an array or list, a tuple can hold objects with different types but they are also immutable. Tuple element position indexing starts from 1. Here is an example of a tuple holding an integer, a string, and the console:
    *
    * {{{
    * val t = (1, "hello", Console)


### PR DESCRIPTION
It is very unclear to someone new that Scala tuple element indexes start from 1 and not from 0, unlike in many other languages. This should be made immediately clear.