### PR TITLE
fixed compilation errors and warnings

### DIFF
--- a/src/main/scala/stdlib/CaseClasses.scala
+++ b/src/main/scala/stdlib/CaseClasses.scala
@@ -71,7 +71,7 @@ object CaseClasses extends AnyFlatSpec with Matchers with org.scalaexercises.def
    * It only makes sense to define case classes if pattern matching is used to decompose data structures. The following object defines a pretty printer function for our lambda calculus representation:
    *
    * {{{
-   * object TermTest {
+   * object TermTest extends App {
    * def printTerm(term: Term) : Unit = {
    * term match {
    * case Var(n) =>

--- a/src/main/scala/stdlib/CaseClasses.scala
+++ b/src/main/scala/stdlib/CaseClasses.scala
@@ -71,8 +71,8 @@ object CaseClasses extends AnyFlatSpec with Matchers with org.scalaexercises.def
    * It only makes sense to define case classes if pattern matching is used to decompose data structures. The following object defines a pretty printer function for our lambda calculus representation:
    *
    * {{{
-   * object TermTest extends Application {
-   * def printTerm(term: Term) = {
+   * object TermTest {
+   * def printTerm(term: Term) : Unit = {
    * term match {
    * case Var(n) =>
    * print(n)
@@ -94,7 +94,7 @@ object CaseClasses extends AnyFlatSpec with Matchers with org.scalaexercises.def
    * val id = Fun("x", Var("x"))
    * val t = Fun("x", Fun("y", App(Var("x"), Var("y"))))
    * printTerm(t)
-   * println
+   * println()
    * println(isIdentityFun(id))
    * println(isIdentityFun(t))
    * }


### PR DESCRIPTION
error: recursive method printTerm needs result type
error: not found: type Application
warning: Auto-application to `()` is deprecated. Supply the empty argument list `()` explicitly to invoke method println, or remove the empty argument list from its definition (Java-defined methods are exempt). In Scala 3, an unapplied method like this will be eta-expanded into a function.