### PR TITLE
Removed equal sign or class doen't compile.

### DIFF
--- a/src/main/scala/stdlib/NamedandDefaultArguments.scala
+++ b/src/main/scala/stdlib/NamedandDefaultArguments.scala
@@ -53,7 +53,7 @@ object NamedandDefaultArguments
    * Given the classes below:
    *
    * {{{
-   * class WithoutClassParameters() = {
+   * class WithoutClassParameters() {
    * def addColors(red: Int, green: Int, blue: Int) = {
    * (red, green, blue)
    * }
@@ -63,7 +63,7 @@ object NamedandDefaultArguments
    * }
    * }
    *
-   * class WithClassParameters(val defaultRed: Int, val defaultGreen: Int, val defaultBlue: Int) = {
+   * class WithClassParameters(val defaultRed: Int, val defaultGreen: Int, val defaultBlue: Int) {
    * def addColors(red: Int, green: Int, blue: Int) = {
    * (red + defaultRed, green + defaultGreen, blue + defaultBlue)
    * }


### PR DESCRIPTION
Removed equal sign after the class signature - **WithoutClassParameters, WithClassParameters** in file **NamedandDefaultArguments.scala** else the classes doesn't compile.