### PR TITLE
Correct a minor regression in Literal Numbers: remove duplicate exercise 'g' from LiteralNumbers (Floats section)

### DIFF
--- a/src/main/scala/stdlib/LiteralNumbers.scala
+++ b/src/main/scala/stdlib/LiteralNumbers.scala
@@ -97,8 +97,7 @@ object LiteralNumbers
       res4: Double,
       res5: Double,
       res6: Double,
-      res7: Double,
-      res8: Double
+      res7: Double
   ) = {
     val a = 3.0
     val b = 3.00
@@ -106,9 +105,8 @@ object LiteralNumbers
     val d = 3f
     val e = 3.22d
     val f = 93e-9
-    val g = 93e-9
-    val h = 0.0
-    val i = 9.23e-9d
+    val g = 0.0
+    val h = 9.23e-9d
 
     a should be(res0)
     b should be(res1)
@@ -118,7 +116,6 @@ object LiteralNumbers
     f should be(res5)
     g should be(res6)
     h should be(res7)
-    i should be(res8)
   }
 
 }

--- a/src/test/scala/stdlib/LiteralNumbersSpec.scala
+++ b/src/test/scala/stdlib/LiteralNumbersSpec.scala
@@ -45,7 +45,7 @@ class LiteralNumbersSpec extends RefSpec with Checkers {
     check(
       Test.testSuccess(
         LiteralNumbers.floatsAndDoublesLiteralNumbers _,
-        3d :: 3d :: 2.73d :: 3d :: 3.22d :: 93e-9 :: 93e-9 :: 0d :: 9.23e-9 :: HNil
+        3d :: 3d :: 2.73d :: 3d :: 3.22d :: 93e-9 :: 0d :: 9.23e-9 :: HNil
       )
     )
   }


### PR DESCRIPTION
Hello, I've noticed that PR #169 seems to have introduced a minor error in Literal Numbers: previously, the values in the Float section looked like this:

```scala
val a = 3.0
val b = 3.00
val c = 2.73
val d = 3f
val e = 3.22d
val f = 93e-9
val g = 93E-9
val h = 0.0
val i = 9.23E-9D
```

This version used both `93e-9` and `93E-9`, to demonstrate that both are acceptable ways of representing the exponent. Furthermore, `i` used `9.23E-9D`, to show that uppercase double literals work. But after #169, it looks like this:

```scala
val a = 3.0
val b = 3.00
val c = 2.73
val d = 3f
val e = 3.22d
val f = 93e-9
val g = 93e-9
val h = 0.0
val i = 9.23e-9d
```

In this version, both `f` and `g` are the same: `93e-9`, and `i` has been swapped to lowercase. Unless I'm mistaken, this was probably not what's intended here! However, I see what caused this- looks like @juanpedromoreno was tidying up the codebase with some `scalafmt` magic after upgrading the version, and `scalafmt` stopped liking the uppercase "E" and "D". So, I would propose to fix this by setting `literals.scientific`  and `literals.double` to `Unchanged`, allowing you to revert the Literal Numbers exercise to the prior format.

Alternatively, if you prefer to keep your `.scalafmt.conf` as-is, you could just remove the duplicate entry `g` in the Literal Numbers exercise and call it a day. If you prefer this, let me know, and I will revise my PR accordingly.