### PR TITLE
misleading excercise

### DIFF
--- a/src/main/scala/stdlib/Formatting.scala
+++ b/src/main/scala/stdlib/Formatting.scala
@@ -50,13 +50,13 @@ object Formatting extends AnyFlatSpec with Matchers with org.scalaexercises.defi
    * Character Literals can be an escape sequence, including hexidecimal:
    */
   def escapeSequenceFormatting(res0: String, res1: String, res2: String) = {
-    val c = '\u0061' //unicode for a
+    val c = '\u0061' // \u0061 -unicode for a
     val e = '\"'
     val f = '\\'
 
-    "%c".format(c) should be(res0)
-    "%c".format(e) should be(res1)
-    "%c".format(f) should be(res2)
+    "%c".format(c) should be(res0) //your ANSWER should have form: "ANSWER"
+    "%c".format(e) should be(res1) //your ANSWER should have form: "\ANSWER"
+    "%c".format(f) should be(res2) //your ANSWER should have form: "\ANSWER"
   }
 
   /**


### PR DESCRIPTION
correct answer based on this app:
![image](https://user-images.githubusercontent.com/1122020/118155476-92339180-b418-11eb-9ce3-6ec72227d1e7.png)

but the real result should be:
```
"%c".format(e)                                                                                                     
val res18: String = "

scala> "%c".format(f)                                                                                                     
val res19: String = \
```
This is misleading (thanks to character escaping in the exercise). 
I'd 
1. remove the exercise or
2. put some comment so user can easier figure it out (this pull request)