### PR TITLE
Update Maps.scala

### DIFF
--- a/src/main/scala/stdlib/Maps.scala
+++ b/src/main/scala/stdlib/Maps.scala
@@ -174,7 +174,7 @@ object Maps extends AnyFlatSpec with Matchers with org.scalaexercises.definition
     val myMap2 =
       Map("WI" -> "Wisconsin", "MI" -> "Michigan", "IA" -> "Iowa", "OH" -> "Ohio")
 
-    myMap1.equals(myMap2) should be(res0)
+    myMap1 == myMap2 should be(res0)
   }
 
 }


### PR DESCRIPTION
For variety show the use of `==` instead of `x.equals(y)` in difference with the previous question, and as a reminder of one item from the previous segment on `List`.