### PR TITLE
Bug in the "Named and Default Arguments" exercises

### DIFF
--- a/src/main/scala/stdlib/NamedandDefaultArguments.scala
+++ b/src/main/scala/stdlib/NamedandDefaultArguments.scala
@@ -56,7 +56,7 @@ object NamedandDefaultArguments
    * Given the classes below:
    *
    * {{{
-   * class WithoutClassParameters() = {
+   * class WithoutClassParameters() {
    * def addColors(red: Int, green: Int, blue: Int) = {
    * (red, green, blue)
    * }
@@ -66,7 +66,7 @@ object NamedandDefaultArguments
    * }
    * }
    *
-   * class WithClassParameters(val defaultRed: Int, val defaultGreen: Int, val defaultBlue: Int) = {
+   * class WithClassParameters(val defaultRed: Int, val defaultGreen: Int, val defaultBlue: Int) {
    * def addColors(red: Int, green: Int, blue: Int) = {
    * (red + defaultRed, green + defaultGreen, blue + defaultBlue)
    * }


### PR DESCRIPTION
While solving the exercises a couple of weeks ago I found that the code wasn't indented correctly (see image below, that belongs to [these](https://www.scala-exercises.org/std_lib/named_and_default_arguments) exercises). Later I found that there was a syntax error in the Scala code displayed. This PR solves it, and _hopefully_ (I guess it wasn't displayed correctly because of the syntax error) it will also fix the indentation of the code.

<img width="1058" alt="NamedAndDefaultArguments" src="https://user-images.githubusercontent.com/24816566/213938132-26fb6550-5776-4c63-902d-da218c64d8b9.png">
