### PR TITLE
Fix: incorrect code sample `toStream`

### DIFF
--- a/src/main/scala/stdlib/Traversables.scala
+++ b/src/main/scala/stdlib/Traversables.scala
@@ -195,8 +195,8 @@ object Traversables extends AnyFlatSpec with Matchers with org.scalaexercises.de
   }
 
   /**
-   * `.to(LazyList)` will convert any `Traversable` to a `LazyList` where elements are evaluated as they
-   * are needed:
+   * `.to(LazyList)` will convert any `Traversable` to a `LazyList` where elements are evaluated as
+   * they are needed:
    */
   def toLazyListFunctionTraversables(res0: Boolean, res1: LazyList[Int]) = {
     val list   = List(4, 6, 7, 8, 9, 13, 14)

--- a/src/main/scala/stdlib/Traversables.scala
+++ b/src/main/scala/stdlib/Traversables.scala
@@ -195,7 +195,7 @@ object Traversables extends AnyFlatSpec with Matchers with org.scalaexercises.de
   }
 
   /**
-   * `toStream` will convert any `Traversable` to a `LazyList` where elements are evaluated as they
+   * `.to(LazyList)` will convert any `Traversable` to a `LazyList` where elements are evaluated as they
    * are needed:
    */
   def toLazyListFunctionTraversables(res0: Boolean, res1: LazyList[Int]) = {


### PR DESCRIPTION
In the `toStream` section, `toStream` is not actually called, rather `.to(LazyList)`.